### PR TITLE
Add channel wallpaper generator: auto-create channels + slice one ima…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-icon",
-  "version": "0.1.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-icon",
-      "version": "0.1.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@nestjs/common": "^11.0.1",

--- a/src/images/channel-wallpaper.controller.spec.ts
+++ b/src/images/channel-wallpaper.controller.spec.ts
@@ -1,0 +1,484 @@
+import 'reflect-metadata';
+import {
+  BadRequestException,
+  ConflictException,
+  ServiceUnavailableException,
+  UnprocessableEntityException,
+  UnsupportedMediaTypeException,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import {
+  ChannelWallpaperController,
+  parseBackgroundColor,
+  namesForRows,
+  prepareRows,
+  resolveSourceImage,
+} from './channel-wallpaper.controller';
+import {
+  withTeamSpeakConnection,
+  listChannelsOnConnection,
+  fetchLiveChannels,
+  invalidateLiveChannelsCache,
+} from '../teamspeak/teamspeak-channels';
+import {
+  createChannelWallpaper,
+  deleteManagedChannels,
+} from '../teamspeak/teamspeak-channel-admin';
+import { sliceWallpaper } from './wallpaper-slicer';
+import { fetchImageSafely, FetchFailedError } from './safe-url-fetcher';
+import { InvalidImageError } from './image-processing';
+import type { ImagesService } from './images.service';
+import type { MetricsService } from '../metrics/metrics.service';
+import { ROLES_KEY } from '../auth/roles.decorator';
+import { OIDC_ADMIN_ROLE } from '../../config';
+import type { GenerateChannelWallpaperDto } from './dto/generate-channel-wallpaper.dto';
+
+const TEST_PUBLIC_BASE_URL = 'https://ts-icon.example.test';
+
+jest.mock('../../config', () => {
+  const actual =
+    jest.requireActual<typeof import('../../config')>('../../config');
+  return { ...actual, getPublicBaseUrl: jest.fn(() => TEST_PUBLIC_BASE_URL) };
+});
+
+jest.mock('./safe-url-fetcher', () => {
+  const actual =
+    jest.requireActual<typeof import('./safe-url-fetcher')>(
+      './safe-url-fetcher',
+    );
+  return { ...actual, fetchImageSafely: jest.fn() };
+});
+
+jest.mock('../teamspeak/teamspeak-channels', () => {
+  const actual = jest.requireActual<
+    typeof import('../teamspeak/teamspeak-channels')
+  >('../teamspeak/teamspeak-channels');
+  return {
+    ...actual,
+    withTeamSpeakConnection: jest.fn(),
+    listChannelsOnConnection: jest.fn(),
+    fetchLiveChannels: jest.fn(),
+    invalidateLiveChannelsCache: jest.fn(),
+  };
+});
+
+jest.mock('../teamspeak/teamspeak-channel-admin', () => ({
+  createChannelWallpaper: jest.fn(),
+  deleteManagedChannels: jest.fn(),
+}));
+
+jest.mock('./wallpaper-slicer', () => {
+  const actual =
+    jest.requireActual<typeof import('./wallpaper-slicer')>(
+      './wallpaper-slicer',
+    );
+  return { ...actual, sliceWallpaper: jest.fn() };
+});
+
+const mockedWithTeamSpeakConnection =
+  withTeamSpeakConnection as jest.MockedFunction<
+    typeof withTeamSpeakConnection
+  >;
+const mockedListChannelsOnConnection =
+  listChannelsOnConnection as jest.MockedFunction<
+    typeof listChannelsOnConnection
+  >;
+const mockedFetchLiveChannels = fetchLiveChannels as jest.MockedFunction<
+  typeof fetchLiveChannels
+>;
+const mockedInvalidateCache =
+  invalidateLiveChannelsCache as jest.MockedFunction<
+    typeof invalidateLiveChannelsCache
+  >;
+const mockedCreateChannelWallpaper =
+  createChannelWallpaper as jest.MockedFunction<typeof createChannelWallpaper>;
+const mockedDeleteManagedChannels =
+  deleteManagedChannels as jest.MockedFunction<typeof deleteManagedChannels>;
+const mockedSliceWallpaper = sliceWallpaper as jest.MockedFunction<
+  typeof sliceWallpaper
+>;
+const mockedFetchImageSafely = fetchImageSafely as jest.MockedFunction<
+  typeof fetchImageSafely
+>;
+
+function createImagesServiceStub(): {
+  imagesService: ImagesService;
+  channelNameInUse: jest.Mock;
+  saveImage: jest.Mock;
+} {
+  const channelNameInUse = jest.fn().mockResolvedValue(false);
+  const saveImage = jest.fn().mockResolvedValue(undefined);
+  const imagesService = {
+    channelNameInUse,
+    saveImage,
+  } as unknown as ImagesService;
+  return { imagesService, channelNameInUse, saveImage };
+}
+
+function createMetricsStub(): {
+  metrics: MetricsService;
+  wallpaperIncMock: jest.Mock;
+  teamspeakErrorsIncMock: jest.Mock;
+} {
+  const wallpaperIncMock = jest.fn();
+  const teamspeakErrorsIncMock = jest.fn();
+  const metrics = {
+    channelWallpaperGenerationsTotal: { inc: wallpaperIncMock },
+    teamspeakErrorsTotal: { inc: teamspeakErrorsIncMock },
+  } as unknown as MetricsService;
+  return { metrics, wallpaperIncMock, teamspeakErrorsIncMock };
+}
+
+function createController(
+  imagesService: ImagesService = createImagesServiceStub().imagesService,
+  metrics: MetricsService = createMetricsStub().metrics,
+): ChannelWallpaperController {
+  return new ChannelWallpaperController(imagesService, metrics);
+}
+
+function createReq(sub = 'test-subject'): Request {
+  return { user: { sub, roles: [] } } as unknown as Request;
+}
+
+function fakeFile(): Express.Multer.File {
+  return { buffer: Buffer.from('fake-image-bytes') } as Express.Multer.File;
+}
+
+const FLAT_CHANNELS = [
+  { cid: '1', name: 'General', bannerGfxUrl: null, pid: null },
+];
+
+beforeEach(() => {
+  mockedListChannelsOnConnection.mockResolvedValue(FLAT_CHANNELS);
+  mockedFetchLiveChannels.mockResolvedValue(FLAT_CHANNELS);
+  mockedWithTeamSpeakConnection.mockImplementation(async (fn) =>
+    fn({} as never),
+  );
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('parseBackgroundColor', () => {
+  it('returns undefined when no hex is given', () => {
+    expect(parseBackgroundColor(undefined)).toBeUndefined();
+  });
+
+  it('parses a #RRGGBB hex string, defaulting alpha to 255', () => {
+    expect(parseBackgroundColor('#112233')).toEqual({
+      r: 0x11,
+      g: 0x22,
+      b: 0x33,
+      alpha: 255,
+    });
+  });
+
+  it('parses a #RRGGBBAA hex string including alpha', () => {
+    expect(parseBackgroundColor('#11223344')).toEqual({
+      r: 0x11,
+      g: 0x22,
+      b: 0x33,
+      alpha: 0x44,
+    });
+  });
+
+  it('throws BadRequestException for a malformed hex string', () => {
+    expect(() => parseBackgroundColor('not-a-color')).toThrow(
+      BadRequestException,
+    );
+  });
+});
+
+describe('namesForRows', () => {
+  it('numbers art and spacer rows independently', () => {
+    const rows = [
+      { depth: 0, isSpacer: false },
+      { depth: 1, isSpacer: true },
+      { depth: 0, isSpacer: false },
+      { depth: 1, isSpacer: true },
+    ];
+    expect(namesForRows('Wall', rows)).toEqual([
+      'Wall 1',
+      'Wall spacer 1',
+      'Wall 2',
+      'Wall spacer 2',
+    ]);
+  });
+});
+
+describe('prepareRows', () => {
+  const channels = [
+    { cid: '1', name: 'Root', bannerGfxUrl: null, pid: null },
+    { cid: '2', name: 'Child', bannerGfxUrl: null, pid: '1' },
+  ];
+
+  it('resolves parentDepth -1 for no parentCid (top-level)', async () => {
+    const { parentDepth } = await prepareRows(channels, undefined, 'flat');
+    expect(parentDepth).toBe(-1);
+  });
+
+  it('resolves parentDepth for an existing nested parentCid', async () => {
+    const { parentDepth } = await prepareRows(channels, '2', 'flat');
+    expect(parentDepth).toBe(1);
+  });
+
+  it('throws BadRequestException when parentCid matches no live channel', async () => {
+    await expect(
+      prepareRows(channels, 'missing', 'flat'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});
+
+describe('resolveSourceImage', () => {
+  it('throws when both file and sourceImageUrl are given', async () => {
+    await expect(
+      resolveSourceImage(fakeFile(), 'https://example.test/x.png'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('throws when neither file nor sourceImageUrl are given', async () => {
+    await expect(
+      resolveSourceImage(undefined, undefined),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('returns the file buffer when a file is given', async () => {
+    const file = fakeFile();
+    await expect(resolveSourceImage(file, undefined)).resolves.toBe(
+      file.buffer,
+    );
+  });
+
+  it('fetches the URL via fetchImageSafely when sourceImageUrl is given', async () => {
+    const buffer = Buffer.from('fetched-bytes');
+    mockedFetchImageSafely.mockResolvedValue({
+      buffer,
+      contentType: 'image/png',
+    });
+    await expect(
+      resolveSourceImage(undefined, 'https://example.test/x.png'),
+    ).resolves.toBe(buffer);
+  });
+
+  it('maps a FetchFailedError from fetchImageSafely to 422, not a generic 500', async () => {
+    mockedFetchImageSafely.mockRejectedValue(
+      new FetchFailedError('too many redirects'),
+    );
+    await expect(
+      resolveSourceImage(undefined, 'https://example.test/x.png'),
+    ).rejects.toBeInstanceOf(UnprocessableEntityException);
+  });
+});
+
+function baseDto(
+  overrides: Partial<GenerateChannelWallpaperDto> = {},
+): GenerateChannelWallpaperDto {
+  return {
+    namePrefix: 'Wall',
+    spacerMode: 'flat',
+    ...overrides,
+  } as GenerateChannelWallpaperDto;
+}
+
+describe('ChannelWallpaperController.generate', () => {
+  it('pre-checks name collisions for the whole prospective range before creating anything', async () => {
+    // relativeRows (the real, unmocked buildAlternatingRowPlan output) always
+    // alternates art/spacer regardless of spacerMode -- 2 rows means "Wall 1"
+    // (art) then "Wall spacer 1" (spacer), which is what the row names are
+    // actually derived from, not sliceWallpaper's mocked return value here.
+    mockedSliceWallpaper.mockResolvedValue([
+      { row: { depth: 0, isSpacer: false }, image: Buffer.from('a') },
+      { row: { depth: 0, isSpacer: false }, image: Buffer.from('b') },
+    ]);
+    const { imagesService, channelNameInUse, saveImage } =
+      createImagesServiceStub();
+    channelNameInUse.mockImplementation((name: string) =>
+      Promise.resolve(name === 'Wall spacer 1'),
+    );
+    const controller = createController(imagesService);
+
+    await expect(
+      controller.generate(fakeFile(), baseDto(), createReq()),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(channelNameInUse).toHaveBeenCalledWith('Wall 1');
+    expect(channelNameInUse).toHaveBeenCalledWith('Wall spacer 1');
+    expect(mockedCreateChannelWallpaper).not.toHaveBeenCalled();
+    expect(saveImage).not.toHaveBeenCalled();
+  });
+
+  it('creates channels in order and saves each successfully-created row image', async () => {
+    mockedSliceWallpaper.mockResolvedValue([
+      { row: { depth: 0, isSpacer: false }, image: Buffer.from('row1') },
+      { row: { depth: 0, isSpacer: true }, image: Buffer.from('row2') },
+    ]);
+    mockedCreateChannelWallpaper.mockResolvedValue({
+      created: [
+        { cid: '10', name: 'Wall 1', depth: 0, isSpacer: false },
+        { cid: '11', name: 'Wall spacer 1', depth: 0, isSpacer: true },
+      ],
+    });
+    const { imagesService, saveImage } = createImagesServiceStub();
+    const { metrics, wallpaperIncMock } = createMetricsStub();
+    const controller = createController(imagesService, metrics);
+
+    const result = await controller.generate(
+      fakeFile(),
+      baseDto(),
+      createReq('subj-1'),
+    );
+
+    expect(result.createdChannels).toEqual([
+      { cid: '10', name: 'Wall 1', kind: 'art', depth: 0 },
+      { cid: '11', name: 'Wall spacer 1', kind: 'spacer', depth: 0 },
+    ]);
+    expect(result.rowCount).toBe(2);
+    expect(saveImage).toHaveBeenNthCalledWith(
+      1,
+      'Wall 1',
+      Buffer.from('row1'),
+      'image/png',
+      '10',
+      'subj-1',
+    );
+    expect(saveImage).toHaveBeenNthCalledWith(
+      2,
+      'Wall spacer 1',
+      Buffer.from('row2'),
+      'image/png',
+      '11',
+      'subj-1',
+    );
+    expect(mockedInvalidateCache).toHaveBeenCalledTimes(1);
+    expect(wallpaperIncMock).toHaveBeenCalledWith({ result: 'success' });
+  });
+
+  it('reports a mid-batch failure without throwing, and only saves images for rows that actually succeeded', async () => {
+    mockedSliceWallpaper.mockResolvedValue([
+      { row: { depth: 0, isSpacer: false }, image: Buffer.from('row1') },
+      { row: { depth: 0, isSpacer: false }, image: Buffer.from('row2') },
+    ]);
+    mockedCreateChannelWallpaper.mockResolvedValue({
+      created: [{ cid: '10', name: 'Wall 1', depth: 0, isSpacer: false }],
+      failedAt: { name: 'Wall 2', error: 'name already exists' },
+    });
+    const { imagesService, saveImage } = createImagesServiceStub();
+    const { metrics, wallpaperIncMock } = createMetricsStub();
+    const controller = createController(imagesService, metrics);
+
+    const result = await controller.generate(
+      fakeFile(),
+      baseDto(),
+      createReq(),
+    );
+
+    expect(result.createdChannels).toHaveLength(1);
+    expect(result.failedAt).toEqual({
+      name: 'Wall 2',
+      error: 'name already exists',
+    });
+    expect(saveImage).toHaveBeenCalledTimes(1);
+    expect(wallpaperIncMock).toHaveBeenCalledWith({
+      result: 'partial-failure',
+    });
+  });
+
+  it('maps an InvalidImageError from slicing to 415, not a generic 503', async () => {
+    mockedSliceWallpaper.mockRejectedValue(
+      new InvalidImageError('not a real image'),
+    );
+    const controller = createController();
+
+    await expect(
+      controller.generate(fakeFile(), baseDto(), createReq()),
+    ).rejects.toBeInstanceOf(UnsupportedMediaTypeException);
+    expect(mockedCreateChannelWallpaper).not.toHaveBeenCalled();
+  });
+
+  it('maps an unexpected connection failure to 503 and increments the TeamSpeak-error counter', async () => {
+    mockedWithTeamSpeakConnection.mockRejectedValue(new Error('ECONNREFUSED'));
+    const { metrics, teamspeakErrorsIncMock } = createMetricsStub();
+    const controller = createController(undefined, metrics);
+
+    await expect(
+      controller.generate(fakeFile(), baseDto(), createReq()),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+    expect(teamspeakErrorsIncMock).toHaveBeenCalledWith({
+      operation: 'generate-channel-wallpaper',
+    });
+  });
+});
+
+describe('ChannelWallpaperController.preview', () => {
+  it('never touches ServerQuery mutation or image storage', async () => {
+    mockedSliceWallpaper.mockResolvedValue([
+      { row: { depth: 0, isSpacer: false }, image: Buffer.from('row1') },
+    ]);
+    const { imagesService, saveImage } = createImagesServiceStub();
+    const controller = createController(imagesService);
+
+    const result = await controller.preview(fakeFile(), baseDto());
+
+    expect(result.rows).toEqual([
+      {
+        depth: 0,
+        isSpacer: false,
+        imageDataUrl: `data:image/png;base64,${Buffer.from('row1').toString('base64')}`,
+      },
+    ]);
+    expect(mockedWithTeamSpeakConnection).not.toHaveBeenCalled();
+    expect(mockedCreateChannelWallpaper).not.toHaveBeenCalled();
+    expect(saveImage).not.toHaveBeenCalled();
+    expect(mockedInvalidateCache).not.toHaveBeenCalled();
+  });
+
+  it('uses the cached fetchLiveChannels() rather than opening a dedicated connection', async () => {
+    mockedSliceWallpaper.mockResolvedValue([]);
+    const controller = createController();
+
+    await controller.preview(fakeFile(), baseDto());
+
+    expect(mockedFetchLiveChannels).toHaveBeenCalledTimes(1);
+    expect(mockedListChannelsOnConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe('ChannelWallpaperController.undo', () => {
+  it('deletes the given cids', async () => {
+    mockedDeleteManagedChannels.mockResolvedValue({
+      deleted: ['1', '2'],
+      failed: [],
+    });
+    const controller = createController();
+
+    const result = await controller.undo({ cids: ['1', '2'] });
+
+    expect(mockedDeleteManagedChannels).toHaveBeenCalledWith(['1', '2']);
+    expect(result).toEqual({ deleted: ['1', '2'], failed: [] });
+  });
+
+  it('maps an unexpected failure to 503', async () => {
+    mockedDeleteManagedChannels.mockRejectedValue(new Error('ECONNREFUSED'));
+    const controller = createController();
+
+    await expect(controller.undo({ cids: ['1'] })).rejects.toBeInstanceOf(
+      ServiceUnavailableException,
+    );
+  });
+});
+
+describe('ChannelWallpaperController role requirements', () => {
+  function rolesOf(methodName: keyof ChannelWallpaperController): unknown {
+    return Reflect.getMetadata(
+      ROLES_KEY,
+      ChannelWallpaperController.prototype[methodName],
+    );
+  }
+
+  it('requires the admin role for generate/preview/undo', () => {
+    expect(rolesOf('generate')).toEqual([OIDC_ADMIN_ROLE]);
+    expect(rolesOf('preview')).toEqual([OIDC_ADMIN_ROLE]);
+    expect(rolesOf('undo')).toEqual([OIDC_ADMIN_ROLE]);
+  });
+});

--- a/src/images/channel-wallpaper.controller.ts
+++ b/src/images/channel-wallpaper.controller.ts
@@ -1,0 +1,441 @@
+import {
+  BadRequestException,
+  Body,
+  ConflictException,
+  Controller,
+  Logger,
+  Post,
+  Req,
+  ServiceUnavailableException,
+  UnprocessableEntityException,
+  UnsupportedMediaTypeException,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiBody, ApiConsumes, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { Express, Request } from 'express';
+
+import { OIDC_ADMIN_ROLE, getPublicBaseUrl } from '../../config';
+import { Roles } from '../auth/roles.decorator';
+import {
+  AuditAction,
+  AuditLoggingInterceptor,
+} from './audit-logging.interceptor';
+import { ImagesService } from './images.service';
+import { MetricsService } from '../metrics/metrics.service';
+import { imageFileFilter } from './images.controller.local';
+import { fetchImageSafely, FetchFailedError } from './safe-url-fetcher';
+import {
+  InvalidImageError,
+  ImageTooLargeError,
+  OUTPUT_MIME_TYPE,
+} from './image-processing';
+import {
+  buildAlternatingRowPlan,
+  sliceWallpaper,
+  MAX_WALLPAPER_ROWS,
+  type WallpaperRow,
+  type WallpaperBackgroundColor,
+} from './wallpaper-slicer';
+import {
+  fetchLiveChannels,
+  computeChannelDepth,
+  expectedBannerUrl,
+  listChannelsOnConnection,
+  withTeamSpeakConnection,
+  invalidateLiveChannelsCache,
+} from '../teamspeak/teamspeak-channels';
+import {
+  createChannelWallpaper,
+  deleteManagedChannels,
+  type WallpaperChannelSlice,
+} from '../teamspeak/teamspeak-channel-admin';
+import { GenerateChannelWallpaperDto } from './dto/generate-channel-wallpaper.dto';
+import { UndoChannelWallpaperDto } from './dto/undo-channel-wallpaper.dto';
+
+const logger = new Logger('ChannelWallpaperController');
+
+// Wallpaper source images can legitimately be tall/detailed (many rows'
+// worth of artwork in one file), so this is deliberately more generous than
+// the 5MB cap on a single 500x44 banner upload in images.controller.local.ts.
+const MAX_WALLPAPER_FILE_SIZE = 20 * 1024 * 1024;
+
+export function parseBackgroundColor(
+  hex?: string,
+): WallpaperBackgroundColor | undefined {
+  if (!hex) return undefined;
+  // Already shape-validated by the DTO's @Matches, but re-checked here since
+  // this function has to actually pull the hex apart into channels.
+  const match = /^#?([0-9a-fA-F]{6})([0-9a-fA-F]{2})?$/.exec(hex);
+  if (!match) {
+    throw new BadRequestException(
+      'backgroundColor must be a #RRGGBB or #RRGGBBAA hex string',
+    );
+  }
+  const [, rgb, alphaHex] = match;
+  return {
+    r: parseInt(rgb.slice(0, 2), 16),
+    g: parseInt(rgb.slice(2, 4), 16),
+    b: parseInt(rgb.slice(4, 6), 16),
+    alpha: alphaHex ? parseInt(alphaHex, 16) : 255,
+  };
+}
+
+/** Art rows and spacer rows are numbered independently, e.g. "Prefix 1", "Prefix spacer 1", "Prefix 2", ... */
+export function namesForRows(
+  namePrefix: string,
+  rows: WallpaperRow[],
+): string[] {
+  let artIndex = 0;
+  let spacerIndex = 0;
+  return rows.map((row) => {
+    if (row.isSpacer) {
+      spacerIndex += 1;
+      return `${namePrefix} spacer ${spacerIndex}`;
+    }
+    artIndex += 1;
+    return `${namePrefix} ${artIndex}`;
+  });
+}
+
+export async function resolveSourceImage(
+  file: Express.Multer.File | undefined,
+  sourceImageUrl: string | undefined,
+): Promise<Buffer> {
+  if (file && sourceImageUrl) {
+    throw new BadRequestException(
+      'Provide either a file upload or sourceImageUrl, not both',
+    );
+  }
+  if (file?.buffer) {
+    return file.buffer;
+  }
+  if (sourceImageUrl) {
+    try {
+      const { buffer } = await fetchImageSafely(sourceImageUrl);
+      return buffer;
+    } catch (err) {
+      if (err instanceof FetchFailedError) {
+        throw new UnprocessableEntityException(err.message);
+      }
+      throw err;
+    }
+  }
+  throw new BadRequestException(
+    'Provide either a file upload or sourceImageUrl',
+  );
+}
+
+interface PreparedRows {
+  relativeRows: WallpaperRow[];
+  parentDepth: number;
+}
+
+/**
+ * Resolves the chosen parent channel's depth in the live tree (-1 for
+ * top-level) and validates it actually exists, then hands back the
+ * candidate row plan -- still relative to that parent (0 = direct child).
+ * `sliceWallpaper()` needs *absolute* depth for correct pixel-offset math
+ * (nesting under an already-deep parent shifts the artwork further right
+ * than nesting at the top level would), so callers combine `parentDepth`
+ * back in themselves; `createChannelWallpaper()` needs the relative depth
+ * as-is, since it reconstructs cpid chains starting from the given parent.
+ *
+ * Deliberately `async` despite having no internal `await`: an invalid
+ * `parentCid` should reject the returned promise rather than throw
+ * synchronously, matching every other validation step in the two callers
+ * that do have real awaits around this one.
+ */
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function prepareRows(
+  channels: {
+    cid: string;
+    pid: string | null;
+    name: string;
+    bannerGfxUrl: string | null;
+  }[],
+  parentCid: string | undefined,
+  spacerMode: 'flat' | 'nested-spacer',
+): Promise<PreparedRows> {
+  const normalizedParentCid = parentCid?.trim() || null;
+  if (
+    normalizedParentCid !== null &&
+    !channels.some((c) => c.cid === normalizedParentCid)
+  ) {
+    throw new BadRequestException(
+      `parentCid "${normalizedParentCid}" does not match any live channel`,
+    );
+  }
+  const parentDepth = computeChannelDepth(normalizedParentCid, channels);
+  const relativeRows = buildAlternatingRowPlan(MAX_WALLPAPER_ROWS, spacerMode);
+  return { relativeRows, parentDepth };
+}
+
+export interface CreatedWallpaperChannelDto {
+  cid: string;
+  name: string;
+  kind: 'art' | 'spacer';
+  depth: number;
+}
+
+@ApiTags('images-local')
+@Controller('images-local/channel-wallpaper')
+export class ChannelWallpaperController {
+  private readonly publicBaseUrl = getPublicBaseUrl();
+
+  constructor(
+    private readonly imagesService: ImagesService,
+    private readonly metrics: MetricsService,
+  ) {}
+
+  @Post()
+  @Roles(OIDC_ADMIN_ROLE)
+  @AuditAction('generate-channel-wallpaper')
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: { fileSize: MAX_WALLPAPER_FILE_SIZE },
+      fileFilter: imageFileFilter,
+    }),
+    AuditLoggingInterceptor,
+  )
+  @ApiOperation({
+    summary:
+      'Slices one large image across an auto-created channel tree and points each new channel banner at its slice (admin only)',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({ type: GenerateChannelWallpaperDto })
+  async generate(
+    @UploadedFile() file: Express.Multer.File | undefined,
+    @Body() dto: GenerateChannelWallpaperDto,
+    @Req() req: Request,
+  ) {
+    const sourceBuffer = await resolveSourceImage(file, dto.sourceImageUrl);
+    const backgroundColor = parseBackgroundColor(dto.backgroundColor);
+    const coverFitMode = dto.coverFitMode !== 'false';
+    const normalizedParentCid = dto.parentCid?.trim() || null;
+
+    try {
+      const result = await withTeamSpeakConnection(async (ts3) => {
+        const channels = await listChannelsOnConnection(ts3);
+        const { relativeRows, parentDepth } = await prepareRows(
+          channels,
+          dto.parentCid,
+          dto.spacerMode,
+        );
+
+        // sliceWallpaper() needs the row's *absolute* tree depth for
+        // correct pixel-offset math -- createChannelWallpaper() below
+        // needs the depth relative to parentCid, so both are derived from
+        // the same relativeRows array rather than one computed from the
+        // other after the fact.
+        const absoluteRows = relativeRows.map((r) => ({
+          ...r,
+          depth: parentDepth + 1 + r.depth,
+        }));
+
+        let slices;
+        try {
+          slices = await sliceWallpaper(sourceBuffer, absoluteRows, {
+            xOffset: dto.xOffset,
+            yOffset: dto.yOffset,
+            backgroundColor,
+            coverFitMode,
+          });
+        } catch (err) {
+          if (err instanceof InvalidImageError) {
+            throw new UnsupportedMediaTypeException(err.message);
+          }
+          if (err instanceof ImageTooLargeError) {
+            throw new UnprocessableEntityException(err.message);
+          }
+          throw err;
+        }
+
+        // Truncation only depends on how many rows fit by height, never on
+        // depth, so the first slices.length entries of relativeRows line
+        // up 1:1 with the truncated slices array by position.
+        const relativeRowsUsed = relativeRows.slice(0, slices.length);
+        const names = namesForRows(dto.namePrefix, relativeRowsUsed);
+
+        const collisions: string[] = [];
+        for (const name of names) {
+          if (await this.imagesService.channelNameInUse(name)) {
+            collisions.push(name);
+          }
+        }
+        if (collisions.length > 0) {
+          throw new ConflictException(
+            `Channel name(s) already in use: ${collisions.join(', ')}`,
+          );
+        }
+
+        const wallpaperSlices: WallpaperChannelSlice[] = slices.map(
+          (slice, i) => ({
+            name: names[i],
+            bannerUrl: expectedBannerUrl(names[i], this.publicBaseUrl),
+            depth: relativeRowsUsed[i].depth,
+            isSpacer: relativeRowsUsed[i].isSpacer,
+          }),
+        );
+
+        const createResult = await createChannelWallpaper(
+          ts3,
+          normalizedParentCid,
+          wallpaperSlices,
+        );
+
+        // Store each successfully created channel's image, in the same
+        // order -- a row whose channel creation itself failed (covered by
+        // createResult.failedAt) never gets this far.
+        for (let i = 0; i < createResult.created.length; i++) {
+          const created = createResult.created[i];
+          await this.imagesService.saveImage(
+            created.name,
+            slices[i].image,
+            OUTPUT_MIME_TYPE,
+            created.cid,
+            req.user?.sub,
+          );
+        }
+
+        return createResult;
+      });
+
+      invalidateLiveChannelsCache();
+
+      const createdChannels: CreatedWallpaperChannelDto[] = result.created.map(
+        (c) => ({
+          cid: c.cid,
+          name: c.name,
+          kind: c.isSpacer ? 'spacer' : 'art',
+          depth: c.depth,
+        }),
+      );
+
+      const outcome = result.failedAt
+        ? 'partial-failure'
+        : createdChannels.length > 0
+          ? 'success'
+          : 'failure';
+      this.metrics.channelWallpaperGenerationsTotal.inc({ result: outcome });
+
+      return {
+        createdChannels,
+        rowCount: createdChannels.length,
+        ...(result.failedAt ? { failedAt: result.failedAt } : {}),
+      };
+    } catch (err) {
+      if (
+        err instanceof BadRequestException ||
+        err instanceof ConflictException ||
+        err instanceof UnsupportedMediaTypeException ||
+        err instanceof UnprocessableEntityException
+      ) {
+        this.metrics.channelWallpaperGenerationsTotal.inc({
+          result: 'failure',
+        });
+        throw err;
+      }
+      logger.error('[generate] Unexpected error:', err);
+      this.metrics.teamspeakErrorsTotal.inc({
+        operation: 'generate-channel-wallpaper',
+      });
+      this.metrics.channelWallpaperGenerationsTotal.inc({ result: 'failure' });
+      throw new ServiceUnavailableException(
+        'TeamSpeak is currently unreachable',
+      );
+    }
+  }
+
+  @Post('preview')
+  @Roles(OIDC_ADMIN_ROLE)
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: { fileSize: MAX_WALLPAPER_FILE_SIZE },
+      fileFilter: imageFileFilter,
+    }),
+  )
+  @ApiOperation({
+    summary:
+      'Runs the same slicing logic as generation, without touching TeamSpeak or storage, for a live preview (admin only)',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({ type: GenerateChannelWallpaperDto })
+  async preview(
+    @UploadedFile() file: Express.Multer.File | undefined,
+    @Body() dto: GenerateChannelWallpaperDto,
+  ) {
+    const sourceBuffer = await resolveSourceImage(file, dto.sourceImageUrl);
+    const backgroundColor = parseBackgroundColor(dto.backgroundColor);
+    const coverFitMode = dto.coverFitMode !== 'false';
+
+    try {
+      // Preview never creates/moves/deletes anything, so it only needs a
+      // cached read of the live channel list (to resolve parentCid's
+      // depth), not a dedicated connection of its own.
+      const channels = await fetchLiveChannels();
+      const { relativeRows, parentDepth } = await prepareRows(
+        channels,
+        dto.parentCid,
+        dto.spacerMode,
+      );
+      const absoluteRows = relativeRows.map((r) => ({
+        ...r,
+        depth: parentDepth + 1 + r.depth,
+      }));
+
+      const slices = await sliceWallpaper(sourceBuffer, absoluteRows, {
+        xOffset: dto.xOffset,
+        yOffset: dto.yOffset,
+        backgroundColor,
+        coverFitMode,
+      });
+      const relativeRowsUsed = relativeRows.slice(0, slices.length);
+
+      return {
+        rows: slices.map((slice, i) => ({
+          depth: relativeRowsUsed[i].depth,
+          isSpacer: relativeRowsUsed[i].isSpacer,
+          imageDataUrl: `data:${OUTPUT_MIME_TYPE};base64,${slice.image.toString('base64')}`,
+        })),
+      };
+    } catch (err) {
+      if (err instanceof InvalidImageError) {
+        throw new UnsupportedMediaTypeException(err.message);
+      }
+      if (err instanceof ImageTooLargeError) {
+        throw new UnprocessableEntityException(err.message);
+      }
+      if (err instanceof BadRequestException) {
+        throw err;
+      }
+      logger.error('[preview] Unexpected error:', err);
+      this.metrics.teamspeakErrorsTotal.inc({ operation: 'list-channels' });
+      throw new ServiceUnavailableException(
+        'TeamSpeak is currently unreachable',
+      );
+    }
+  }
+
+  @Post('undo')
+  @Roles(OIDC_ADMIN_ROLE)
+  @AuditAction('undo-channel-wallpaper')
+  @UseInterceptors(AuditLoggingInterceptor)
+  @ApiOperation({
+    summary: 'Deletes previously-generated channels by cid (admin only)',
+  })
+  async undo(@Body() dto: UndoChannelWallpaperDto) {
+    try {
+      return await deleteManagedChannels(dto.cids);
+    } catch (err) {
+      logger.error('[undo] Unexpected error:', err);
+      this.metrics.teamspeakErrorsTotal.inc({
+        operation: 'undo-channel-wallpaper',
+      });
+      throw new ServiceUnavailableException(
+        'TeamSpeak is currently unreachable',
+      );
+    }
+  }
+}

--- a/src/images/dto/generate-channel-wallpaper.dto.ts
+++ b/src/images/dto/generate-channel-wallpaper.dto.ts
@@ -1,0 +1,88 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsIn,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Matches,
+  MaxLength,
+} from 'class-validator';
+import { MAX_CHANNEL_NAME_LENGTH } from './channel-name-validation.pipe';
+
+const MAX_URL_LENGTH = 2048;
+
+export type WallpaperSpacerMode = 'flat' | 'nested-spacer';
+
+/**
+ * Body for `POST images-local/channel-wallpaper` and its `/preview`
+ * counterpart -- both take the same shape, since preview must run the exact
+ * same slicing/depth logic generation will use. Multipart form fields all
+ * arrive as strings, so numeric fields (`xOffset`/`yOffset`) rely on the
+ * global `ValidationPipe`'s `transform: true` + `@Type(() => Number)` to
+ * coerce them; `coverFitMode` is deliberately kept as a plain 'true'/'false'
+ * string rather than transformed to a real boolean, since `Boolean('false')`
+ * is `true` -- a footgun not worth the convenience.
+ */
+export class GenerateChannelWallpaperDto {
+  @ApiPropertyOptional({
+    description:
+      'cid to parent the generated channels under; omitted/empty means top-level',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  parentCid?: string;
+
+  @ApiProperty({ example: 'wallpaper-row', maxLength: MAX_CHANNEL_NAME_LENGTH })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(MAX_CHANNEL_NAME_LENGTH)
+  namePrefix!: string;
+
+  @ApiProperty({ enum: ['flat', 'nested-spacer'] })
+  @IsIn(['flat', 'nested-spacer'])
+  spacerMode!: WallpaperSpacerMode;
+
+  @ApiPropertyOptional({
+    description:
+      'Alternative to uploading a file: fetch the source image from this URL instead.',
+    maxLength: MAX_URL_LENGTH,
+  })
+  @IsOptional()
+  @IsUrl()
+  @MaxLength(MAX_URL_LENGTH)
+  sourceImageUrl?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  xOffset?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  yOffset?: number;
+
+  @ApiPropertyOptional({
+    description: '#RRGGBB or #RRGGBBAA hex string; default fully transparent.',
+    example: '#00000000',
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(/^#?[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/)
+  backgroundColor?: string;
+
+  @ApiPropertyOptional({
+    description:
+      "'true' (default) or 'false' -- kept as a string, not a boolean, deliberately (see class doc).",
+    enum: ['true', 'false'],
+  })
+  @IsOptional()
+  @IsIn(['true', 'false'])
+  coverFitMode?: 'true' | 'false';
+}

--- a/src/images/dto/undo-channel-wallpaper.dto.ts
+++ b/src/images/dto/undo-channel-wallpaper.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsString } from 'class-validator';
+import { MAX_WALLPAPER_ROWS } from '../wallpaper-slicer';
+
+/** Body for `POST images-local/channel-wallpaper/undo`. */
+export class UndoChannelWallpaperDto {
+  @ApiProperty({ type: [String] })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(MAX_WALLPAPER_ROWS)
+  @IsString({ each: true })
+  cids!: string[];
+}

--- a/src/images/images.controller.local.spec.ts
+++ b/src/images/images.controller.local.spec.ts
@@ -196,7 +196,7 @@ beforeEach(() => {
   // resolution defaults to "a live channel called 'chan' exists and it's
   // brand new" unless a specific test overrides it.
   mockedFetchLiveChannels.mockResolvedValue([
-    { cid: 'cid-chan', name: 'Chan', bannerGfxUrl: null },
+    { cid: 'cid-chan', name: 'Chan', bannerGfxUrl: null, pid: null },
   ]);
 });
 
@@ -237,7 +237,7 @@ describe('imageFileFilter', () => {
 describe('resolveUploadChannel', () => {
   it('rejects with ChannelNotFoundError when no live channel matches the given name', async () => {
     mockedFetchLiveChannels.mockResolvedValue([
-      { cid: 'cid-1', name: 'Something Else', bannerGfxUrl: null },
+      { cid: 'cid-1', name: 'Something Else', bannerGfxUrl: null, pid: null },
     ]);
     const { imagesService } = createImagesServiceStub();
 
@@ -248,7 +248,7 @@ describe('resolveUploadChannel', () => {
 
   it('resolves as an update when an existing row already has this exact channelId', async () => {
     mockedFetchLiveChannels.mockResolvedValue([
-      { cid: 'cid-chan', name: 'Chan', bannerGfxUrl: null },
+      { cid: 'cid-chan', name: 'Chan', bannerGfxUrl: null, pid: null },
     ]);
     const { imagesService, findByChannelId, channelNameInUse } =
       createImagesServiceStub();
@@ -265,7 +265,7 @@ describe('resolveUploadChannel', () => {
 
   it('resolves as a plain new-channel create when the channelId is new and the name is not taken', async () => {
     mockedFetchLiveChannels.mockResolvedValue([
-      { cid: 'cid-chan', name: 'Chan', bannerGfxUrl: null },
+      { cid: 'cid-chan', name: 'Chan', bannerGfxUrl: null, pid: null },
     ]);
     const { imagesService, findByChannelId, channelNameInUse } =
       createImagesServiceStub();
@@ -279,7 +279,7 @@ describe('resolveUploadChannel', () => {
 
   it('rejects with ChannelNameConflictError when the channelId is new but a different row already owns this channelName', async () => {
     mockedFetchLiveChannels.mockResolvedValue([
-      { cid: 'cid-chan', name: 'Chan', bannerGfxUrl: null },
+      { cid: 'cid-chan', name: 'Chan', bannerGfxUrl: null, pid: null },
     ]);
     const { imagesService, findByChannelId, channelNameInUse } =
       createImagesServiceStub();
@@ -452,7 +452,7 @@ describe('ImagesLocalController.listChannels', () => {
 
   it('returns the normalized channel list on success', async () => {
     mockedFetchLiveChannels.mockResolvedValue([
-      { cid: '1', name: 'Foo Bar', bannerGfxUrl: null },
+      { cid: '1', name: 'Foo Bar', bannerGfxUrl: null, pid: null },
     ]);
     const controller = createController();
     await expect(controller.listChannels()).resolves.toEqual({
@@ -596,19 +596,30 @@ describe('ImagesLocalController.listChannelBannerUrls', () => {
         cid: 'cid-1',
         name: 'General',
         bannerGfxUrl: `${TEST_PUBLIC_BASE_URL}/images/general.png`,
+        pid: null,
       },
-      { cid: 'cid-2', name: 'Music', bannerGfxUrl: null },
+      { cid: 'cid-2', name: 'Music', bannerGfxUrl: null, pid: 'cid-1' },
     ]);
     const controller = createController();
 
     await expect(controller.listChannelBannerUrls()).resolves.toEqual({
       channels: [
         {
+          cid: 'cid-1',
           name: 'general',
           bannerGfxUrl: `${TEST_PUBLIC_BASE_URL}/images/general.png`,
           managed: true,
+          pid: null,
+          depth: 0,
         },
-        { name: 'music', bannerGfxUrl: null, managed: false },
+        {
+          cid: 'cid-2',
+          name: 'music',
+          bannerGfxUrl: null,
+          managed: false,
+          pid: 'cid-1',
+          depth: 1,
+        },
       ],
     });
   });
@@ -636,7 +647,7 @@ describe('ImagesLocalController.setBannerUrl', () => {
 
   it('sets the banner URL to the expected value for the resolved channel', async () => {
     mockedFetchLiveChannels.mockResolvedValue([
-      { cid: 'cid-chan', name: 'Chan', bannerGfxUrl: null },
+      { cid: 'cid-chan', name: 'Chan', bannerGfxUrl: null, pid: null },
     ]);
     mockedSetChannelBannerUrl.mockResolvedValue(undefined);
     const controller = createController();
@@ -664,7 +675,7 @@ describe('ImagesLocalController.setBannerUrl', () => {
 
   it('returns 503 when setChannelBannerUrl itself fails', async () => {
     mockedFetchLiveChannels.mockResolvedValue([
-      { cid: 'cid-chan', name: 'Chan', bannerGfxUrl: null },
+      { cid: 'cid-chan', name: 'Chan', bannerGfxUrl: null, pid: null },
     ]);
     mockedSetChannelBannerUrl.mockRejectedValue(new Error('rejected'));
     const controller = createController();

--- a/src/images/images.controller.local.ts
+++ b/src/images/images.controller.local.ts
@@ -48,6 +48,7 @@ import {
   isManagedByUs,
   setChannelBannerUrl,
   applyBannerUrlsForAllChannels,
+  computeChannelDepth,
   type LiveChannel,
 } from '../teamspeak/teamspeak-channels';
 import {
@@ -678,9 +679,12 @@ export class ImagesLocalController {
           items: {
             type: 'object',
             properties: {
+              cid: { type: 'string' },
               name: { type: 'string' },
               bannerGfxUrl: { type: 'string', nullable: true },
               managed: { type: 'boolean' },
+              pid: { type: 'string', nullable: true },
+              depth: { type: 'number' },
             },
           },
         },
@@ -696,9 +700,12 @@ export class ImagesLocalController {
     try {
       const liveChannels = await fetchLiveChannels();
       const channels = liveChannels.map((c) => ({
+        cid: c.cid,
         name: normalizeChannelName(c.name),
         bannerGfxUrl: c.bannerGfxUrl,
         managed: isManagedByUs(c, this.publicBaseUrl),
+        pid: c.pid,
+        depth: computeChannelDepth(c.cid, liveChannels),
       }));
       return { channels };
     } catch (err) {

--- a/src/images/images.module.local.ts
+++ b/src/images/images.module.local.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ImagesLocalController } from './images.controller.local';
+import { ChannelWallpaperController } from './channel-wallpaper.controller';
 import { ImagesService } from './images.service';
 import { MetricsModule } from '../metrics/metrics.module';
 
 @Module({
   imports: [MetricsModule],
-  controllers: [ImagesLocalController],
+  controllers: [ImagesLocalController, ChannelWallpaperController],
   providers: [ImagesService],
 })
 export class ImagesModuleLocal {}

--- a/src/images/wallpaper-slicer.spec.ts
+++ b/src/images/wallpaper-slicer.spec.ts
@@ -1,0 +1,298 @@
+import sharp from 'sharp';
+import {
+  sliceWallpaper,
+  buildAlternatingRowPlan,
+  CHANNEL_DEPTH_OFFSET_PX,
+  MAX_WALLPAPER_ROWS,
+  type WallpaperRow,
+} from './wallpaper-slicer';
+import {
+  InvalidImageError,
+  ImageTooLargeError,
+  TARGET_WIDTH,
+  TARGET_HEIGHT,
+} from './image-processing';
+
+// Builds a source image made of N horizontal, TARGET_HEIGHT-tall bands, each
+// a distinct solid color -- lets pixel assertions confirm exactly which
+// band of the source ended up in which sliced row, the same style as
+// image-processing.spec.ts's real (non-mocked) sharp round-trips.
+async function stripedImage(
+  width: number,
+  bandColors: { r: number; g: number; b: number }[],
+  bandHeight: number = TARGET_HEIGHT,
+): Promise<Buffer> {
+  const composites = bandColors.map((color, i) => ({
+    input: {
+      create: {
+        width,
+        height: bandHeight,
+        channels: 3 as const,
+        background: color,
+      },
+    },
+    top: i * bandHeight,
+    left: 0,
+  }));
+  return sharp({
+    create: {
+      width,
+      height: bandColors.length * bandHeight,
+      channels: 3,
+      background: { r: 0, g: 0, b: 0 },
+    },
+  })
+    .composite(composites)
+    .png()
+    .toBuffer();
+}
+
+async function pixelAt(image: Buffer, x: number, y: number) {
+  const { data, info } = await sharp(image)
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const idx = (y * info.width + x) * info.channels;
+  return {
+    r: data[idx],
+    g: data[idx + 1],
+    b: data[idx + 2],
+    a: info.channels === 4 ? data[idx + 3] : 255,
+  };
+}
+
+const RED = { r: 255, g: 0, b: 0 };
+const GREEN = { r: 0, g: 255, b: 0 };
+const BLUE = { r: 0, g: 0, b: 255 };
+const YELLOW = { r: 255, g: 255, b: 0 };
+
+describe('buildAlternatingRowPlan', () => {
+  it('produces exactly maxRows rows', () => {
+    expect(buildAlternatingRowPlan(5, 'flat')).toHaveLength(5);
+    expect(buildAlternatingRowPlan(0, 'flat')).toHaveLength(0);
+  });
+
+  it('flat mode: every row (art and spacer) is at depth 0', () => {
+    const rows = buildAlternatingRowPlan(6, 'flat');
+    expect(rows.every((r) => r.depth === 0)).toBe(true);
+    expect(rows.map((r) => r.isSpacer)).toEqual([
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+    ]);
+  });
+
+  it('nested-spacer mode: art rows stay at depth 0, spacers are at depth 1', () => {
+    const rows = buildAlternatingRowPlan(4, 'nested-spacer');
+    expect(rows).toEqual<WallpaperRow[]>([
+      { depth: 0, isSpacer: false },
+      { depth: 1, isSpacer: true },
+      { depth: 0, isSpacer: false },
+      { depth: 1, isSpacer: true },
+    ]);
+  });
+
+  it('MAX_WALLPAPER_ROWS is a positive, finite safety ceiling', () => {
+    expect(MAX_WALLPAPER_ROWS).toBeGreaterThan(0);
+    expect(Number.isFinite(MAX_WALLPAPER_ROWS)).toBe(true);
+  });
+});
+
+describe('sliceWallpaper', () => {
+  it('truncates to exactly the rows that fit, never padding a partial trailing row', async () => {
+    // 3 full bands + a 20px partial band that doesn't make a 4th full row.
+    const input = await stripedImage(TARGET_WIDTH, [RED, GREEN, BLUE]);
+    const shortImage = await sharp(input)
+      .resize({ width: TARGET_WIDTH, height: 3 * TARGET_HEIGHT + 20 })
+      .png()
+      .toBuffer();
+
+    const candidateRows = buildAlternatingRowPlan(10, 'flat');
+    const slices = await sliceWallpaper(shortImage, candidateRows);
+
+    expect(slices).toHaveLength(3);
+  });
+
+  it('produces zero rows for an image shorter than a single row', async () => {
+    const input = await stripedImage(TARGET_WIDTH, [RED]);
+    const tinyImage = await sharp(input)
+      .resize({ width: TARGET_WIDTH, height: 10 })
+      .png()
+      .toBuffer();
+
+    const slices = await sliceWallpaper(
+      tinyImage,
+      buildAlternatingRowPlan(5, 'flat'),
+    );
+    expect(slices).toHaveLength(0);
+  });
+
+  it('each output row samples the correct band of the source (flat mode, no depth offset)', async () => {
+    const input = await stripedImage(TARGET_WIDTH, [RED, GREEN, BLUE, YELLOW]);
+    const rows = buildAlternatingRowPlan(4, 'flat');
+
+    const slices = await sliceWallpaper(input, rows, { coverFitMode: false });
+
+    expect(slices).toHaveLength(4);
+    const expectedColors = [RED, GREEN, BLUE, YELLOW];
+    for (let i = 0; i < slices.length; i++) {
+      const px = await pixelAt(slices[i].image, 10, 10);
+      expect(px).toEqual({ ...expectedColors[i], a: 255 });
+    }
+  });
+
+  it('applies the CHANNEL_DEPTH_OFFSET_PX horizontal shift for a nested (depth > 0) row', async () => {
+    // Each band's left CHANNEL_DEPTH_OFFSET_PX columns are RED, the rest
+    // GREEN, so a depth-1 row (shifted right by the offset) should sample
+    // GREEN starting from column 0, while a depth-0 row would still see the
+    // RED strip at column 0.
+    const width = TARGET_WIDTH + CHANNEL_DEPTH_OFFSET_PX;
+    const band = sharp({
+      create: { width, height: TARGET_HEIGHT, channels: 3, background: GREEN },
+    }).composite([
+      {
+        input: {
+          create: {
+            width: CHANNEL_DEPTH_OFFSET_PX,
+            height: TARGET_HEIGHT,
+            channels: 3,
+            background: RED,
+          },
+        },
+        left: 0,
+        top: 0,
+      },
+    ]);
+    const bandBuffer = await band.png().toBuffer();
+    const image = await sharp({
+      create: {
+        width,
+        height: TARGET_HEIGHT * 2,
+        channels: 3,
+        background: RED,
+      },
+    })
+      .composite([
+        { input: bandBuffer, left: 0, top: 0 },
+        { input: bandBuffer, left: 0, top: TARGET_HEIGHT },
+      ])
+      .png()
+      .toBuffer();
+
+    const rows: WallpaperRow[] = [
+      { depth: 0, isSpacer: false },
+      { depth: 1, isSpacer: true },
+    ];
+    // coverFitMode stays at its default (true): maxDepth is 1, so the
+    // pre-resize target width is exactly TARGET_WIDTH + CHANNEL_DEPTH_OFFSET_PX
+    // -- the same width this fixture image was already built at, so the
+    // resize step is a no-op and the hand-placed RED/GREEN columns land
+    // exactly where expected.
+    const slices = await sliceWallpaper(image, rows);
+
+    expect(slices).toHaveLength(2);
+    const depth0Px = await pixelAt(slices[0].image, 0, 5);
+    expect(depth0Px).toEqual({ ...RED, a: 255 });
+
+    const depth1Px = await pixelAt(slices[1].image, 0, 5);
+    expect(depth1Px).toEqual({ ...GREEN, a: 255 });
+  });
+
+  it('fills with the given background color where a nested row runs past the source edge', async () => {
+    // No coverFitMode pre-resize (targetWidth stays 500 even for a depth-1
+    // row), so the depth-offset x-shift pushes the requested window right
+    // past the source's actual width -- the uncovered strip on the right
+    // must be the given background color, not source content wrapping or an
+    // error.
+    const input = await stripedImage(TARGET_WIDTH, [BLUE]);
+    const rows: WallpaperRow[] = [{ depth: 1, isSpacer: true }];
+    const background = { r: 5, g: 6, b: 7, alpha: 255 };
+
+    const slices = await sliceWallpaper(input, rows, {
+      coverFitMode: false,
+      backgroundColor: background,
+    });
+
+    expect(slices).toHaveLength(1);
+    const rightEdgePx = await pixelAt(slices[0].image, TARGET_WIDTH - 1, 5);
+    expect(rightEdgePx).toEqual({
+      r: background.r,
+      g: background.g,
+      b: background.b,
+      a: background.alpha,
+    });
+  });
+
+  it("treats backgroundColor.alpha as a 0-255 byte, not sharp's native 0-1 float", async () => {
+    // Regression test: sharp's create.background.alpha is 0-1 (via the
+    // `color` module) and clamps anything >= 1 to fully opaque -- confirmed
+    // directly against the installed sharp version. A background alpha of
+    // 128 (mid-range) must come out as ~128 in the output, not 255; if the
+    // 0-255-to-0-1 conversion were ever removed, this would fail (128
+    // unconverted would clamp to fully opaque = 255).
+    const input = await stripedImage(TARGET_WIDTH, [BLUE]);
+    const rows: WallpaperRow[] = [{ depth: 1, isSpacer: true }];
+    const background = { r: 5, g: 6, b: 7, alpha: 128 };
+
+    const slices = await sliceWallpaper(input, rows, {
+      coverFitMode: false,
+      backgroundColor: background,
+    });
+
+    const rightEdgePx = await pixelAt(slices[0].image, TARGET_WIDTH - 1, 5);
+    expect(rightEdgePx.a).toBeGreaterThan(120);
+    expect(rightEdgePx.a).toBeLessThan(136);
+  });
+
+  it('coverFitMode pre-resizes the whole image so a nested row has real content instead of running off the edge', async () => {
+    // Same setup as the background-fill test, but with coverFitMode (the
+    // default) -- the source is resized wider first specifically so a
+    // depth-1 row's window still lands on real image content.
+    const input = await stripedImage(TARGET_WIDTH, [BLUE]);
+    const rows: WallpaperRow[] = [{ depth: 1, isSpacer: true }];
+
+    const slices = await sliceWallpaper(input, rows);
+
+    expect(slices).toHaveLength(1);
+    const rightEdgePx = await pixelAt(slices[0].image, TARGET_WIDTH - 1, 5);
+    expect(rightEdgePx).toEqual({ ...BLUE, a: 255 });
+  });
+
+  it('rejects a corrupt/non-image buffer with InvalidImageError', async () => {
+    const notAnImage = Buffer.from(
+      'definitely not an image, padded out further with text',
+    );
+    await expect(
+      sliceWallpaper(notAnImage, buildAlternatingRowPlan(3, 'flat')),
+    ).rejects.toBeInstanceOf(InvalidImageError);
+  });
+
+  it('rejects an oversized source image with ImageTooLargeError', async () => {
+    const huge = await sharp({
+      create: { width: 25000, height: 40, channels: 3, background: RED },
+    })
+      .png()
+      .toBuffer();
+    await expect(
+      sliceWallpaper(huge, buildAlternatingRowPlan(3, 'flat')),
+    ).rejects.toBeInstanceOf(ImageTooLargeError);
+  });
+
+  it('produces output rows at the canonical TARGET_WIDTH x TARGET_HEIGHT size', async () => {
+    const input = await stripedImage(TARGET_WIDTH, [RED, GREEN]);
+    const slices = await sliceWallpaper(
+      input,
+      buildAlternatingRowPlan(2, 'flat'),
+      {
+        coverFitMode: false,
+      },
+    );
+    for (const slice of slices) {
+      const meta = await sharp(slice.image).metadata();
+      expect(meta.width).toBe(TARGET_WIDTH);
+      expect(meta.height).toBe(TARGET_HEIGHT);
+    }
+  });
+});

--- a/src/images/wallpaper-slicer.ts
+++ b/src/images/wallpaper-slicer.ts
@@ -1,0 +1,249 @@
+import sharp, { type OutputInfo } from 'sharp';
+import {
+  TARGET_WIDTH,
+  TARGET_HEIGHT,
+  InvalidImageError,
+  ImageTooLargeError,
+} from './image-processing';
+
+// The horizontal pixel shift applied per nesting-depth level, so a deeply
+// nested channel's banner slice is drawn from further right in the source
+// image -- keeping the artwork visually continuous despite the TeamSpeak
+// client indenting each nesting level. This number itself (11px) is not
+// derived from this codebase; it's carried over from observing the intended
+// behavior of a reference tool built for a different (TS5) client version,
+// and is flagged for re-confirmation against a real TS6 client (see the
+// implementation plan's verification section) the same way TARGET_HEIGHT
+// already is.
+export const CHANNEL_DEPTH_OFFSET_PX = 11;
+
+// Safety ceiling on how many channels a single generation run can produce.
+// Row count is otherwise auto-computed purely from the uploaded image's
+// height, so without this cap a pathologically tall source image could make
+// one admin action spawn an unbounded number of channels.
+export const MAX_WALLPAPER_ROWS = 300;
+
+// A wallpaper source image can legitimately be dozens of rows tall (up to
+// MAX_WALLPAPER_ROWS * TARGET_HEIGHT = 13,200px at the narrowest, more once
+// depth-offset padding is added to the width), so this ceiling is
+// deliberately much more generous than image-processing.ts's
+// MAX_DIMENSION_PX/MAX_PIXELS (which target a single 500x44 banner) --
+// while still bounded, so a decompression-bomb-shaped file can't force an
+// unbounded decode.
+const MAX_SOURCE_DIMENSION_PX = 20_000;
+const MAX_SOURCE_PIXELS = 60_000_000;
+
+const ACCEPTED_FORMATS = new Set(['png', 'jpeg', 'webp', 'gif']);
+
+export interface WallpaperRow {
+  depth: number;
+  isSpacer: boolean;
+}
+
+/**
+ * Generates up to `maxRows` candidate rows alternating art/spacer
+ * (art, spacer, art, spacer, ...), per the chosen preset. `sliceWallpaper()`
+ * truncates this down to however many rows the uploaded image's height
+ * actually supports -- this just produces the (over-generous) candidate
+ * sequence to truncate from.
+ *
+ * - 'flat': every row, art and spacer alike, at depth 0 -- siblings of the
+ *   chosen parent channel.
+ * - 'nested-spacer': art rows stay at depth 0; each spacer is a child of the
+ *   art channel immediately before it (depth 1) -- a common real-world
+ *   technique (the spacer visually collapses into its channel) that needs
+ *   CHANNEL_DEPTH_OFFSET_PX compensation to keep the artwork aligned despite
+ *   the extra indentation.
+ */
+export function buildAlternatingRowPlan(
+  maxRows: number,
+  mode: 'flat' | 'nested-spacer',
+): WallpaperRow[] {
+  const rows: WallpaperRow[] = [];
+  for (let i = 0; i < maxRows; i++) {
+    const isSpacer = i % 2 === 1;
+    const depth = mode === 'nested-spacer' && isSpacer ? 1 : 0;
+    rows.push({ depth, isSpacer });
+  }
+  return rows;
+}
+
+export interface WallpaperBackgroundColor {
+  r: number;
+  g: number;
+  b: number;
+  /** 0-255, matching the byte range of every other channel here -- converted
+   * to sharp's own 0-1 alpha scale internally, so callers never need to know
+   * about that mismatch. */
+  alpha: number;
+}
+
+export interface WallpaperSliceOptions {
+  xOffset?: number;
+  yOffset?: number;
+  backgroundColor?: WallpaperBackgroundColor;
+  /** Default true. */
+  coverFitMode?: boolean;
+}
+
+export interface WallpaperSlice {
+  row: WallpaperRow;
+  image: Buffer;
+}
+
+const DEFAULT_BACKGROUND: WallpaperBackgroundColor = {
+  r: 0,
+  g: 0,
+  b: 0,
+  alpha: 0,
+};
+
+/**
+ * Slices one large source image into a sequence of TARGET_WIDTH x
+ * TARGET_HEIGHT row images, one per channel, so that stacking them
+ * top-to-bottom in the channel tree (accounting for each row's nesting
+ * depth) reproduces a continuous "wallpaper" image.
+ *
+ * The row count is not `candidateRows.length` -- it's truncated to however
+ * many whole TARGET_HEIGHT-tall rows actually fit within the resized
+ * image's real height, so a short source image doesn't get padded with
+ * blank trailing rows and a tall one doesn't get cut off mid-row.
+ */
+export async function sliceWallpaper(
+  input: Buffer,
+  candidateRows: WallpaperRow[],
+  options: WallpaperSliceOptions = {},
+): Promise<WallpaperSlice[]> {
+  let metadata;
+  try {
+    metadata = await sharp(input).metadata();
+  } catch {
+    throw new InvalidImageError('The file could not be decoded as an image');
+  }
+
+  const { format, width, height } = metadata;
+  if (!format || !ACCEPTED_FORMATS.has(format)) {
+    throw new InvalidImageError(
+      `Unsupported or unrecognized image format: ${format ?? 'unknown'}`,
+    );
+  }
+  if (!width || !height) {
+    throw new InvalidImageError('Image is missing width/height metadata');
+  }
+  if (
+    width > MAX_SOURCE_DIMENSION_PX ||
+    height > MAX_SOURCE_DIMENSION_PX ||
+    width * height > MAX_SOURCE_PIXELS
+  ) {
+    throw new ImageTooLargeError(
+      `Image dimensions ${width}x${height} exceed the maximum allowed size`,
+    );
+  }
+
+  const coverFitMode = options.coverFitMode !== false;
+  const xOffset = options.xOffset ?? 0;
+  const yOffset = options.yOffset ?? 0;
+  const backgroundColor = options.backgroundColor ?? DEFAULT_BACKGROUND;
+  // sharp's `create.background` alpha is a 0-1 float (via the `color`
+  // module it delegates to), not the 0-255 byte range this module's own
+  // WallpaperBackgroundColor uses for every other channel -- confirmed
+  // directly against the installed sharp version, since passing a raw
+  // 0-255 value through unconverted would silently clamp any alpha above 1
+  // to fully opaque instead of the intended partial transparency.
+  const background = {
+    r: backgroundColor.r,
+    g: backgroundColor.g,
+    b: backgroundColor.b,
+    alpha: backgroundColor.alpha / 255,
+  };
+
+  const maxDepth = Math.max(0, ...candidateRows.map((r) => r.depth));
+  const targetWidth = coverFitMode
+    ? TARGET_WIDTH + maxDepth * CHANNEL_DEPTH_OFFSET_PX
+    : TARGET_WIDTH;
+
+  let resized: { data: Buffer; info: OutputInfo };
+  try {
+    resized = await sharp(input)
+      .rotate()
+      .resize({ width: targetWidth })
+      .ensureAlpha()
+      .png()
+      .toBuffer({ resolveWithObject: true });
+  } catch {
+    throw new InvalidImageError('The image could not be processed');
+  }
+
+  const resizedHeight = resized.info.height;
+
+  const rowsToRender: WallpaperRow[] = [];
+  let remainingHeight = resizedHeight;
+  for (const row of candidateRows) {
+    if (remainingHeight - TARGET_HEIGHT < 0) break;
+    remainingHeight -= TARGET_HEIGHT;
+    rowsToRender.push(row);
+  }
+
+  const slices: WallpaperSlice[] = [];
+  let y = 0;
+  for (const row of rowsToRender) {
+    const x = row.depth * CHANNEL_DEPTH_OFFSET_PX - xOffset;
+    const rowY = y + yOffset;
+
+    // sharp's composite() requires the input to be no larger than the
+    // canvas it's composited onto, in both dimensions, regardless of
+    // position -- unlike Canvas 2D's drawImage, it has no built-in
+    // tolerance for a source rectangle that runs past the source image's
+    // edges (a deep row's x-offset can easily push its 500px-wide window
+    // past the resized image's right edge). So the desired
+    // TARGET_WIDTH x TARGET_HEIGHT window is first clamped to whatever
+    // actually overlaps the resized source, that (guaranteed in-bounds,
+    // guaranteed canvas-sized-or-smaller) region is extracted on its own,
+    // and only that piece is composited onto the blank, background-filled
+    // canvas at the equivalent relative position -- reproducing the same
+    // "background shows through wherever the source didn't reach" result.
+    const clampedX = Math.max(0, x);
+    const clampedY = Math.max(0, rowY);
+    const clampedRight = Math.min(x + TARGET_WIDTH, resized.info.width);
+    const clampedBottom = Math.min(rowY + TARGET_HEIGHT, resizedHeight);
+    const extractWidth = clampedRight - clampedX;
+    const extractHeight = clampedBottom - clampedY;
+
+    let canvas = sharp({
+      create: {
+        width: TARGET_WIDTH,
+        height: TARGET_HEIGHT,
+        channels: 4,
+        background,
+      },
+    });
+
+    if (extractWidth > 0 && extractHeight > 0) {
+      const extracted = await sharp(resized.data)
+        .extract({
+          left: clampedX,
+          top: clampedY,
+          width: extractWidth,
+          height: extractHeight,
+        })
+        .toBuffer();
+      canvas = canvas.composite([
+        {
+          input: extracted,
+          left: clampedX - x,
+          top: clampedY - rowY,
+        },
+      ]);
+    }
+    // If there's no overlap at all (extractWidth/extractHeight <= 0 --
+    // the requested window is entirely outside the resized source), the
+    // row is just the plain background-filled canvas with nothing
+    // composited onto it.
+
+    const image = await canvas.png().toBuffer();
+    slices.push({ row, image });
+    y += TARGET_HEIGHT;
+  }
+
+  return slices;
+}

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -94,6 +94,14 @@ export class MetricsService {
     registers: [this.registry],
   });
 
+  /** Channel-wallpaper generation runs, labeled by outcome. */
+  readonly channelWallpaperGenerationsTotal = new Counter({
+    name: 'channel_wallpaper_generations_total',
+    help: 'Total channel-wallpaper generation runs, labeled by result (success/partial-failure/failure).',
+    labelNames: ['result'] as const,
+    registers: [this.registry],
+  });
+
   /** The registry's every metric, rendered in the Prometheus text exposition format. */
   async getMetricsText(): Promise<string> {
     return this.registry.metrics();

--- a/src/teamspeak/channel-id-matching.spec.ts
+++ b/src/teamspeak/channel-id-matching.spec.ts
@@ -5,7 +5,7 @@ describe('matchChannelIdsToRows', () => {
   it('matches a row to a live channel whose normalized name equals the row channelName', () => {
     const rows = [{ channelName: 'general' }];
     const liveChannels: LiveChannel[] = [
-      { cid: '1', name: 'General', bannerGfxUrl: null },
+      { cid: '1', name: 'General', bannerGfxUrl: null, pid: null },
     ];
 
     const result = matchChannelIdsToRows(rows, liveChannels);
@@ -19,7 +19,7 @@ describe('matchChannelIdsToRows', () => {
   it('normalizes live channel names the same way the rest of the app does (umlauts, whitespace, punctuation)', () => {
     const rows = [{ channelName: 'rohre' }];
     const liveChannels: LiveChannel[] = [
-      { cid: '42', name: 'Röhre!!!', bannerGfxUrl: null },
+      { cid: '42', name: 'Röhre!!!', bannerGfxUrl: null, pid: null },
     ];
 
     const result = matchChannelIdsToRows(rows, liveChannels);
@@ -31,7 +31,7 @@ describe('matchChannelIdsToRows', () => {
   it('reports a row with no live match at all as unmatched, not an error', () => {
     const rows = [{ channelName: 'deleted-channel' }];
     const liveChannels: LiveChannel[] = [
-      { cid: '1', name: 'Something Else', bannerGfxUrl: null },
+      { cid: '1', name: 'Something Else', bannerGfxUrl: null, pid: null },
     ];
 
     const result = matchChannelIdsToRows(rows, liveChannels);
@@ -47,8 +47,8 @@ describe('matchChannelIdsToRows', () => {
       { channelName: 'music' },
     ];
     const liveChannels: LiveChannel[] = [
-      { cid: '1', name: 'General', bannerGfxUrl: null },
-      { cid: '2', name: 'Music', bannerGfxUrl: null },
+      { cid: '1', name: 'General', bannerGfxUrl: null, pid: null },
+      { cid: '2', name: 'Music', bannerGfxUrl: null, pid: null },
     ];
 
     const result = matchChannelIdsToRows(rows, liveChannels);
@@ -74,7 +74,7 @@ describe('matchChannelIdsToRows', () => {
 
   it('returns nothing at all when there are no rows to match', () => {
     const liveChannels: LiveChannel[] = [
-      { cid: '1', name: 'General', bannerGfxUrl: null },
+      { cid: '1', name: 'General', bannerGfxUrl: null, pid: null },
     ];
 
     const result = matchChannelIdsToRows([], liveChannels);
@@ -91,8 +91,8 @@ describe('matchChannelIdsToRows', () => {
     // live channel is later in the array overwriting the map entry.
     const rows = [{ channelName: 'rohre' }];
     const liveChannels: LiveChannel[] = [
-      { cid: '1', name: 'Röhre', bannerGfxUrl: null },
-      { cid: '2', name: 'Rohre', bannerGfxUrl: null },
+      { cid: '1', name: 'Röhre', bannerGfxUrl: null, pid: null },
+      { cid: '2', name: 'Rohre', bannerGfxUrl: null, pid: null },
     ];
 
     const result = matchChannelIdsToRows(rows, liveChannels);

--- a/src/teamspeak/teamspeak-channel-admin.spec.ts
+++ b/src/teamspeak/teamspeak-channel-admin.spec.ts
@@ -1,0 +1,268 @@
+import { TeamSpeak } from 'ts3-nodejs-library';
+import {
+  createManagedChannel,
+  deleteManagedChannels,
+  createChannelWallpaper,
+  type WallpaperChannelSlice,
+} from './teamspeak-channel-admin';
+import {
+  fetchLiveChannels,
+  invalidateLiveChannelsCache,
+} from './teamspeak-channels';
+
+jest.mock('ts3-nodejs-library', () => ({
+  TeamSpeak: { connect: jest.fn() },
+  QueryProtocol: { RAW: 'raw', SSH: 'ssh' },
+}));
+
+jest.mock('../../config', () => ({
+  ...jest.requireActual<typeof import('../../config')>('../../config'),
+  getTeamSpeakCredentials: jest.fn(() => ({
+    username: 'user',
+    password: 'pass',
+  })),
+}));
+
+const mockedConnect = jest.spyOn(TeamSpeak, 'connect');
+
+beforeEach(() => {
+  invalidateLiveChannelsCache();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+function fakeChannel(cid: string, name: string) {
+  return { cid, name };
+}
+
+describe('createManagedChannel', () => {
+  it('creates a permanent channel with the banner URL set at creation time', async () => {
+    const channelCreate = jest
+      .fn()
+      .mockResolvedValue(fakeChannel('10', 'Art 1'));
+    const fakeTeamSpeak = { on: jest.fn(), channelCreate, quit: jest.fn() };
+    mockedConnect.mockResolvedValue(fakeTeamSpeak as never);
+
+    const ts3 = await TeamSpeak.connect({} as never);
+    const result = await createManagedChannel(ts3, {
+      parentCid: '5',
+      name: 'Art 1',
+      orderAfterCid: '4',
+      bannerUrl: 'https://example.test/images/art-1.png',
+    });
+
+    expect(channelCreate).toHaveBeenCalledWith('Art 1', {
+      cpid: '5',
+      channelOrder: 4,
+      channelFlagPermanent: true,
+      channelBannerGfxUrl: 'https://example.test/images/art-1.png',
+    });
+    expect(result).toEqual({ cid: '10', name: 'Art 1' });
+  });
+
+  it('uses cpid "0" for a null parentCid (top-level)', async () => {
+    const channelCreate = jest.fn().mockResolvedValue(fakeChannel('1', 'Top'));
+    const fakeTeamSpeak = { on: jest.fn(), channelCreate, quit: jest.fn() };
+    mockedConnect.mockResolvedValue(fakeTeamSpeak as never);
+
+    const ts3 = await TeamSpeak.connect({} as never);
+    await createManagedChannel(ts3, {
+      parentCid: null,
+      name: 'Top',
+      orderAfterCid: null,
+      bannerUrl: 'https://example.test/images/top.png',
+    });
+
+    expect(channelCreate).toHaveBeenCalledWith(
+      'Top',
+      expect.objectContaining({ cpid: '0', channelOrder: undefined }),
+    );
+  });
+});
+
+describe('deleteManagedChannels', () => {
+  it('deletes every given cid over a single connection and invalidates the cache', async () => {
+    const channelDelete = jest.fn().mockResolvedValue([]);
+    const quit = jest.fn().mockResolvedValue(undefined);
+    mockedConnect.mockResolvedValue({
+      on: jest.fn(),
+      channelDelete,
+      quit,
+    } as never);
+
+    const result = await deleteManagedChannels(['1', '2', '3']);
+
+    expect(mockedConnect).toHaveBeenCalledTimes(1);
+    expect(channelDelete).toHaveBeenCalledTimes(3);
+    expect(channelDelete).toHaveBeenNthCalledWith(1, '1', true);
+    expect(result).toEqual({ deleted: ['1', '2', '3'], failed: [] });
+  });
+
+  it('is tolerant of individual failures, continuing with the rest', async () => {
+    const channelDelete = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error('channel not found'))
+      .mockResolvedValueOnce([]);
+    mockedConnect.mockResolvedValue({
+      on: jest.fn(),
+      channelDelete,
+      quit: jest.fn().mockResolvedValue(undefined),
+    } as never);
+
+    const result = await deleteManagedChannels(['1', '2', '3']);
+
+    expect(result.deleted).toEqual(['1', '3']);
+    expect(result.failed).toEqual([{ cid: '2', error: 'channel not found' }]);
+  });
+
+  it('invalidates the live-channels cache once finished', async () => {
+    mockedConnect.mockResolvedValueOnce({
+      on: jest.fn(),
+      channelList: jest
+        .fn()
+        .mockResolvedValue([{ cid: '1', name: 'General', bannerGfxUrl: null }]),
+      quit: jest.fn().mockResolvedValue(undefined),
+    } as never);
+    const cachedBefore = await fetchLiveChannels();
+    expect(cachedBefore).toHaveLength(1);
+
+    mockedConnect.mockResolvedValueOnce({
+      on: jest.fn(),
+      channelDelete: jest.fn().mockResolvedValue([]),
+      quit: jest.fn().mockResolvedValue(undefined),
+    } as never);
+    await deleteManagedChannels(['1']);
+
+    mockedConnect.mockResolvedValueOnce({
+      on: jest.fn(),
+      channelList: jest.fn().mockResolvedValue([]),
+      quit: jest.fn().mockResolvedValue(undefined),
+    } as never);
+    const refreshed = await fetchLiveChannels();
+
+    expect(mockedConnect).toHaveBeenCalledTimes(3);
+    expect(refreshed).toEqual([]);
+  });
+});
+
+describe('createChannelWallpaper', () => {
+  function slice(
+    name: string,
+    depth: number,
+    isSpacer: boolean,
+  ): WallpaperChannelSlice {
+    return {
+      name,
+      depth,
+      isSpacer,
+      bannerUrl: `https://example.test/images/${name}.png`,
+    };
+  }
+
+  it('creates every slice in order, chaining sibling order at each depth (flat mode)', async () => {
+    let nextCid = 100;
+    const channelCreate = jest.fn().mockImplementation((name: string) => {
+      return Promise.resolve(fakeChannel(String(nextCid++), name));
+    });
+    const fakeTeamSpeak = { on: jest.fn(), channelCreate, quit: jest.fn() };
+
+    const slices = [
+      slice('Art1', 0, false),
+      slice('Spacer1', 0, true),
+      slice('Art2', 0, false),
+    ];
+    const result = await createChannelWallpaper(
+      fakeTeamSpeak as never,
+      '5',
+      slices,
+    );
+
+    expect(result.created.map((c) => c.name)).toEqual([
+      'Art1',
+      'Spacer1',
+      'Art2',
+    ]);
+    expect(channelCreate).toHaveBeenNthCalledWith(
+      1,
+      'Art1',
+      expect.objectContaining({ cpid: '5', channelOrder: undefined }),
+    );
+    expect(channelCreate).toHaveBeenNthCalledWith(
+      2,
+      'Spacer1',
+      expect.objectContaining({ cpid: '5', channelOrder: 100 }),
+    );
+    expect(channelCreate).toHaveBeenNthCalledWith(
+      3,
+      'Art2',
+      expect.objectContaining({ cpid: '5', channelOrder: 101 }),
+    );
+  });
+
+  it('nested-spacer mode: a depth-1 row parents under the specific art channel created right before it, not the batch root', async () => {
+    let nextCid = 200;
+    const channelCreate = jest.fn().mockImplementation((name: string) => {
+      return Promise.resolve(fakeChannel(String(nextCid++), name));
+    });
+    const fakeTeamSpeak = { on: jest.fn(), channelCreate, quit: jest.fn() };
+
+    const slices = [
+      slice('Art1', 0, false), // cid 200
+      slice('Spacer1', 1, true), // should parent under 200
+      slice('Art2', 0, false), // cid 202, parents under batch root
+      slice('Spacer2', 1, true), // should parent under 202, NOT under 200
+    ];
+    await createChannelWallpaper(fakeTeamSpeak as never, '5', slices);
+
+    expect(channelCreate).toHaveBeenNthCalledWith(
+      1,
+      'Art1',
+      expect.objectContaining({ cpid: '5' }),
+    );
+    expect(channelCreate).toHaveBeenNthCalledWith(
+      2,
+      'Spacer1',
+      expect.objectContaining({ cpid: '200', channelOrder: undefined }),
+    );
+    expect(channelCreate).toHaveBeenNthCalledWith(
+      3,
+      'Art2',
+      expect.objectContaining({ cpid: '5', channelOrder: 200 }),
+    );
+    expect(channelCreate).toHaveBeenNthCalledWith(
+      4,
+      'Spacer2',
+      expect.objectContaining({ cpid: '202', channelOrder: undefined }),
+    );
+  });
+
+  it('stops on a mid-batch failure and reports which rows succeeded/failed, without rollback', async () => {
+    const channelCreate = jest
+      .fn()
+      .mockResolvedValueOnce(fakeChannel('1', 'Art1'))
+      .mockRejectedValueOnce(new Error('name already exists'));
+    const fakeTeamSpeak = { on: jest.fn(), channelCreate, quit: jest.fn() };
+
+    const slices = [
+      slice('Art1', 0, false),
+      slice('Art2', 0, false),
+      slice('Art3', 0, false),
+    ];
+    const result = await createChannelWallpaper(
+      fakeTeamSpeak as never,
+      null,
+      slices,
+    );
+
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0].name).toBe('Art1');
+    expect(result.failedAt).toEqual({
+      name: 'Art2',
+      error: 'name already exists',
+    });
+    expect(channelCreate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/teamspeak/teamspeak-channel-admin.ts
+++ b/src/teamspeak/teamspeak-channel-admin.ts
@@ -1,0 +1,185 @@
+import { Logger } from '@nestjs/common';
+import { TeamSpeak } from 'ts3-nodejs-library';
+import type * as Props from 'ts3-nodejs-library/lib/types/PropertyTypes';
+import {
+  withTeamSpeakConnection,
+  invalidateLiveChannelsCache,
+} from './teamspeak-channels';
+
+const logger = new Logger('TeamSpeakChannelAdmin');
+
+export interface CreateManagedChannelParams {
+  parentCid: string | null;
+  name: string;
+  /** cid to sort this channel right under, or null to sort first. */
+  orderAfterCid: string | null;
+  bannerUrl: string;
+}
+
+/**
+ * Creates a single permanent channel with its banner URL already set at
+ * creation time. `channelBannerGfxUrl`'s value is deterministic from the
+ * channel name alone (see `expectedBannerUrl()`), so it doesn't need to wait
+ * for the image to be sliced/stored -- passing it here instead of a
+ * follow-up `channelEdit()` halves the ServerQuery round-trips per row.
+ *
+ * `channelFlagPermanent: true` is required -- a channel created without it
+ * is temporary and disappears once empty. Takes an already-open `ts3`
+ * (caller owns the connection lifecycle) so a whole generation run of many
+ * rows is one connection, not one per row -- same reasoning as
+ * `applyBannerUrlsForAllChannels` in `teamspeak-channels.ts`.
+ *
+ * `Props.ChannelEdit` already declares `cpid`/`channelOrder`/
+ * `channelFlagPermanent` (unlike `channelBannerGfxUrl`, which needs the same
+ * intersection-cast trick `setChannelBannerUrl` uses), so only that one
+ * property needs the cast. `channelOrder` is declared as `number`, even
+ * though what it actually holds is a channel's cid (every cid elsewhere in
+ * this codebase, e.g. `LiveChannel.cid`, is a `string`) -- converted with
+ * `Number()` here rather than folded into the same cast, since the value is
+ * genuinely numeric and this keeps the one remaining cast limited to the
+ * property that's actually missing from the library's types.
+ */
+export async function createManagedChannel(
+  ts3: TeamSpeak,
+  params: CreateManagedChannelParams,
+): Promise<{ cid: string; name: string }> {
+  const channel = await ts3.channelCreate(params.name, {
+    cpid: params.parentCid ?? '0',
+    channelOrder:
+      params.orderAfterCid !== null ? Number(params.orderAfterCid) : undefined,
+    channelFlagPermanent: true,
+    channelBannerGfxUrl: params.bannerUrl,
+  } as Props.ChannelEdit & { channelBannerGfxUrl: string });
+  return { cid: channel.cid, name: channel.name };
+}
+
+export interface DeleteManagedChannelsResult {
+  deleted: string[];
+  failed: { cid: string; error: string }[];
+}
+
+/**
+ * Deletes each given channel by cid, tolerant of individual failures (e.g.
+ * a channel already deleted by someone else) so one bad cid doesn't abort
+ * the whole cleanup -- the "undo a bad generation run" primitive. Opens its
+ * own single connection for the whole batch.
+ */
+export async function deleteManagedChannels(
+  cids: string[],
+): Promise<DeleteManagedChannelsResult> {
+  const result = await withTeamSpeakConnection(async (ts3) => {
+    const deleted: string[] = [];
+    const failed: { cid: string; error: string }[] = [];
+    for (const cid of cids) {
+      try {
+        await ts3.channelDelete(cid, true);
+        deleted.push(cid);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn(
+          `[deleteManagedChannels] Failed to delete ${cid}: ${message}`,
+        );
+        failed.push({ cid, error: message });
+      }
+    }
+    return { deleted, failed };
+  });
+  invalidateLiveChannelsCache();
+  return result;
+}
+
+export interface WallpaperChannelSlice {
+  name: string;
+  bannerUrl: string;
+  depth: number;
+  isSpacer: boolean;
+}
+
+export interface CreatedWallpaperChannel {
+  cid: string;
+  name: string;
+  depth: number;
+  isSpacer: boolean;
+}
+
+export interface CreateChannelWallpaperResult {
+  created: CreatedWallpaperChannel[];
+  failedAt?: { name: string; error: string };
+}
+
+/**
+ * Creates every slice's channel in order on a single already-open
+ * connection. `slice.depth` is relative to `parentCid` (0 = direct child of
+ * it), and rows are reconstructed into a tree the same way an indented
+ * outline is: a row at depth d parents under the most recently created row
+ * at depth d-1 (or `parentCid` itself at depth 0) -- this is what lets the
+ * "nested spacer" preset put each spacer under the specific art channel
+ * right before it, rather than under the fixed batch root. Sibling order
+ * within a parent chains from the previous row created under that same
+ * parent, so rows land top-to-bottom in the tree exactly as sliced.
+ *
+ * Real ServerQuery has no transactions -- on a mid-batch failure this stops
+ * and reports which rows succeeded/failed rather than attempting a
+ * rollback; the caller can retry or use `deleteManagedChannels()` to clean
+ * up the partial result.
+ */
+export async function createChannelWallpaper(
+  ts3: TeamSpeak,
+  parentCid: string | null,
+  slices: WallpaperChannelSlice[],
+): Promise<CreateChannelWallpaperResult> {
+  const created: CreatedWallpaperChannel[] = [];
+  // cid to use as `cpid` for a row at a given depth -- depth 0 always
+  // parents under the fixed batch root; deeper depths parent under
+  // whichever row was most recently created one level shallower.
+  const parentCidByDepth = new Map<number, string | null>([[0, parentCid]]);
+  // Most recently created sibling's cid at each depth, so the next row at
+  // that depth sorts directly after it instead of always being inserted
+  // first. Reset for depths below any newly created row, since that row
+  // starts a fresh (empty) subtree -- without this, a depth like 1 could
+  // otherwise carry over a sibling cid from underneath a *different*
+  // parent higher up in a previous row.
+  const lastSiblingCidByDepth = new Map<number, string>();
+
+  for (const slice of slices) {
+    const depth = slice.depth;
+    // Falls back to the batch root if a row plan ever produced a depth
+    // whose immediate parent depth wasn't created yet -- shouldn't happen
+    // given how buildAlternatingRowPlan() only ever steps depth by +1 at a
+    // time, but keeps this function from crashing on a malformed plan.
+    const actualParentCid = parentCidByDepth.get(depth) ?? parentCid;
+
+    try {
+      const channel = await createManagedChannel(ts3, {
+        parentCid: actualParentCid,
+        name: slice.name,
+        orderAfterCid: lastSiblingCidByDepth.get(depth) ?? null,
+        bannerUrl: slice.bannerUrl,
+      });
+
+      lastSiblingCidByDepth.set(depth, channel.cid);
+      parentCidByDepth.set(depth + 1, channel.cid);
+      for (const key of [...lastSiblingCidByDepth.keys()]) {
+        if (key > depth) lastSiblingCidByDepth.delete(key);
+      }
+      for (const key of [...parentCidByDepth.keys()]) {
+        if (key > depth + 1) parentCidByDepth.delete(key);
+      }
+
+      created.push({
+        cid: channel.cid,
+        name: channel.name,
+        depth,
+        isSpacer: slice.isSpacer,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(
+        `[createChannelWallpaper] Failed to create "${slice.name}": ${message}`,
+      );
+      return { created, failedAt: { name: slice.name, error: message } };
+    }
+  }
+
+  return { created };
+}

--- a/src/teamspeak/teamspeak-channels.spec.ts
+++ b/src/teamspeak/teamspeak-channels.spec.ts
@@ -6,6 +6,7 @@ import {
   setChannelBannerUrl,
   applyBannerUrlsForAllChannels,
   invalidateLiveChannelsCache,
+  computeChannelDepth,
   type LiveChannel,
 } from './teamspeak-channels';
 
@@ -62,8 +63,9 @@ describe('fetchLiveChannels', () => {
         cid: '1',
         name: 'General',
         bannerGfxUrl: 'https://example.test/images/general',
+        pid: null,
       },
-      { cid: '2', name: 'Music', bannerGfxUrl: null },
+      { cid: '2', name: 'Music', bannerGfxUrl: null, pid: null },
     ]);
     expect(quit).toHaveBeenCalledTimes(1);
   });
@@ -112,7 +114,7 @@ describe('fetchLiveChannels', () => {
 
     expect(mockedConnect).toHaveBeenCalledTimes(1);
     expect(firstResult).toEqual([
-      { cid: '1', name: 'General', bannerGfxUrl: null },
+      { cid: '1', name: 'General', bannerGfxUrl: null, pid: null },
     ]);
     expect(secondResult).toEqual(firstResult);
   });
@@ -191,6 +193,7 @@ describe('isManagedByUs', () => {
       cid: '1',
       name: 'General',
       bannerGfxUrl: `${PUBLIC_BASE_URL}/images/general.png`,
+      pid: null,
     };
     expect(isManagedByUs(channel, PUBLIC_BASE_URL)).toBe(true);
   });
@@ -200,6 +203,7 @@ describe('isManagedByUs', () => {
       cid: '1',
       name: 'General',
       bannerGfxUrl: null,
+      pid: null,
     };
     expect(isManagedByUs(channel, PUBLIC_BASE_URL)).toBe(false);
   });
@@ -209,6 +213,7 @@ describe('isManagedByUs', () => {
       cid: '1',
       name: 'General',
       bannerGfxUrl: 'https://someone-elses-host.example/banner.png',
+      pid: null,
     };
     expect(isManagedByUs(channel, PUBLIC_BASE_URL)).toBe(false);
   });
@@ -224,8 +229,46 @@ describe('isManagedByUs', () => {
       cid: '1',
       name: 'General',
       bannerGfxUrl: `${PUBLIC_BASE_URL}/images/general`,
+      pid: null,
     };
     expect(isManagedByUs(channel, PUBLIC_BASE_URL)).toBe(false);
+  });
+});
+
+describe('computeChannelDepth', () => {
+  const flatChannels: LiveChannel[] = [
+    { cid: '1', name: 'A', bannerGfxUrl: null, pid: null },
+    { cid: '2', name: 'B', bannerGfxUrl: null, pid: null },
+  ];
+
+  const nestedChannels: LiveChannel[] = [
+    { cid: '1', name: 'Root', bannerGfxUrl: null, pid: null },
+    { cid: '2', name: 'Child', bannerGfxUrl: null, pid: '1' },
+    { cid: '3', name: 'Grandchild', bannerGfxUrl: null, pid: '2' },
+  ];
+
+  it('returns -1 for a null cid (no parent chosen, i.e. top-level)', () => {
+    expect(computeChannelDepth(null, flatChannels)).toBe(-1);
+  });
+
+  it('returns 0 for a top-level channel', () => {
+    expect(computeChannelDepth('1', flatChannels)).toBe(0);
+  });
+
+  it('returns 0 for the root of a nested tree', () => {
+    expect(computeChannelDepth('1', nestedChannels)).toBe(0);
+  });
+
+  it('returns 1 for a direct child', () => {
+    expect(computeChannelDepth('2', nestedChannels)).toBe(1);
+  });
+
+  it('returns 2 for a grandchild', () => {
+    expect(computeChannelDepth('3', nestedChannels)).toBe(2);
+  });
+
+  it('returns -1 for a cid that does not exist in the given channel list', () => {
+    expect(computeChannelDepth('unknown', nestedChannels)).toBe(-1);
   });
 });
 

--- a/src/teamspeak/teamspeak-channels.ts
+++ b/src/teamspeak/teamspeak-channels.ts
@@ -31,19 +31,29 @@ export interface LiveChannel {
    * channel's banner is already pointed at our own managed image.
    */
   bannerGfxUrl: string | null;
+  /**
+   * The parent channel's cid, or `null` for a top-level channel. TeamSpeak's
+   * ServerQuery reports a top-level channel's `pid` as `"0"`, normalized to
+   * `null` here so `computeChannelDepth()` doesn't need to know that
+   * convention itself.
+   */
+  pid: string | null;
 }
 
 /**
  * Opens a TeamSpeak connection, runs `fn` against it, and always disconnects
- * afterward -- success or failure. Shared by every operation in this module
- * that needs a live connection (listing channels, editing a channel's
- * banner URL), so there's one place that knows how to connect/attach an
- * error handler/disconnect, instead of that boilerplate being duplicated at
- * every call site. Using `finally` for the disconnect (rather than only
- * calling `quit()` after a successful operation, the previous shape of this
- * code) also means a connection is no longer leaked if `fn` throws.
+ * afterward -- success or failure. Shared by every operation that needs a
+ * live connection (listing channels, editing a channel's banner URL,
+ * creating/deleting channels in `teamspeak-channel-admin.ts`), so there's one
+ * place that knows how to connect/attach an error handler/disconnect,
+ * instead of that boilerplate being duplicated at every call site. Using
+ * `finally` for the disconnect (rather than only calling `quit()` after a
+ * successful operation, the previous shape of this code) also means a
+ * connection is no longer leaked if `fn` throws. Exported so callers that
+ * need to do more than one operation on a single connection (e.g. list
+ * channels then create several more) can still go through this one place.
  */
-async function withTeamSpeakConnection<T>(
+export async function withTeamSpeakConnection<T>(
   fn: (ts3: TeamSpeak) => Promise<T>,
 ): Promise<T> {
   logger.log('[TeamSpeak] Starting connection to TeamSpeak...');
@@ -73,8 +83,14 @@ function toLiveChannel(c: {
   cid: string;
   name: string;
   bannerGfxUrl?: string;
+  pid?: string;
 }): LiveChannel {
-  return { cid: c.cid, name: c.name, bannerGfxUrl: c.bannerGfxUrl || null };
+  return {
+    cid: c.cid,
+    name: c.name,
+    bannerGfxUrl: c.bannerGfxUrl || null,
+    pid: c.pid && c.pid !== '0' ? c.pid : null,
+  };
 }
 
 // Both the admin channel picker (GET /images-local/channels) and the
@@ -155,16 +171,57 @@ export function invalidateLiveChannelsCache(): void {
   inFlightFetch = null;
 }
 
-async function connectAndListChannels(): Promise<LiveChannel[]> {
-  return withTeamSpeakConnection(async (ts3) => {
-    // ts3.channelList() already requests the -banner flag internally, so
-    // every returned channel's .bannerGfxUrl getter is populated without
-    // any extra ServerQuery call.
-    const channels = await ts3.channelList();
-    const result = channels.map(toLiveChannel);
-    logger.log(`[fetchLiveChannels] Found ${result.length} channel(s).`);
-    return result;
-  });
+/**
+ * Lists channels on an already-open connection, without opening or closing
+ * one of its own. Exported so a caller that needs to do more than just list
+ * channels on a single connection (e.g. `teamspeak-channel-admin.ts`'s
+ * channel-wallpaper generation, which lists channels once and then creates
+ * several more on that same connection) doesn't have to duplicate this
+ * mapping logic.
+ */
+export async function listChannelsOnConnection(
+  ts3: TeamSpeak,
+): Promise<LiveChannel[]> {
+  // ts3.channelList() already requests the -banner flag internally, so
+  // every returned channel's .bannerGfxUrl getter is populated without
+  // any extra ServerQuery call.
+  const channels = await ts3.channelList();
+  const result = channels.map(toLiveChannel);
+  logger.log(`[fetchLiveChannels] Found ${result.length} channel(s).`);
+  return result;
+}
+
+function connectAndListChannels(): Promise<LiveChannel[]> {
+  return withTeamSpeakConnection(listChannelsOnConnection);
+}
+
+/**
+ * Walks the `pid` parent chain from `cid` up to the root, counting hops, to
+ * find how deeply nested a channel is in the channel tree. `cid === null`
+ * (no parent chosen, i.e. top-level) returns `-1`, so a direct child of it
+ * -- a genuinely top-level channel -- comes out to depth 0, matching every
+ * other depth-0 assumption in the channel-wallpaper row-plan presets.
+ *
+ * A `cid` that isn't found in `channels` (e.g. a stale/invalid parent) is
+ * treated the same as `-1` (top-level) rather than throwing -- callers that
+ * care about that distinction should check for the channel's existence
+ * themselves first.
+ */
+export function computeChannelDepth(
+  cid: string | null,
+  channels: LiveChannel[],
+): number {
+  if (cid === null) return -1;
+  const byId = new Map(channels.map((c) => [c.cid, c]));
+  let depth = 0;
+  let current = byId.get(cid);
+  if (!current) return -1;
+  while (current.pid !== null) {
+    depth++;
+    current = byId.get(current.pid);
+    if (!current) break;
+  }
+  return depth;
 }
 
 /**

--- a/webapp-banner-tool/package-lock.json
+++ b/webapp-banner-tool/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webapp-banner-tool",
-  "version": "0.1.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webapp-banner-tool",
-      "version": "0.1.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "cropperjs": "1.6.2",

--- a/webapp-banner-tool/src/App.test.tsx
+++ b/webapp-banner-tool/src/App.test.tsx
@@ -17,6 +17,9 @@ vi.mock('./components/ChannelGallery', () => ({
 vi.mock('./components/BannerUrlManager', () => ({
   default: () => <div>banner-url-manager-page</div>,
 }));
+vi.mock('./components/ChannelWallpaperGenerator', () => ({
+  default: () => <div>channel-wallpaper-generator-page</div>,
+}));
 
 const { useAuthMock, useCanUploadMock, useIsAdminMock } = vi.hoisted(() => ({
   useAuthMock: vi.fn(),
@@ -132,6 +135,63 @@ describe('App routing', () => {
 
     expect(screen.queryByText('banner-url-manager-page')).not.toBeInTheDocument();
     expect(screen.getByText('Access denied')).toBeInTheDocument();
+  });
+
+  it('renders the channel wallpaper generator at /wallpaper for an admin', () => {
+    useAuthMock.mockReturnValue({ username: 'admin-alice', logout: vi.fn() });
+    useCanUploadMock.mockReturnValue(true);
+    useIsAdminMock.mockReturnValue(true);
+
+    render(
+      <MemoryRouter initialEntries={['/wallpaper']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('channel-wallpaper-generator-page')).toBeInTheDocument();
+  });
+
+  it('redirects /wallpaper to /access-denied for a non-admin, even one who can upload', () => {
+    useAuthMock.mockReturnValue({ username: 'editor-bob', logout: vi.fn() });
+    useCanUploadMock.mockReturnValue(true);
+    useIsAdminMock.mockReturnValue(false);
+
+    render(
+      <MemoryRouter initialEntries={['/wallpaper']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('channel-wallpaper-generator-page')).not.toBeInTheDocument();
+    expect(screen.getByText('Access denied')).toBeInTheDocument();
+  });
+
+  it('only shows the Channel Wallpaper nav link to admins', () => {
+    useAuthMock.mockReturnValue({ username: 'editor-bob', logout: vi.fn() });
+    useCanUploadMock.mockReturnValue(true);
+    useIsAdminMock.mockReturnValue(false);
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('Channel Wallpaper')).not.toBeInTheDocument();
+  });
+
+  it('shows the Channel Wallpaper nav link to admins', () => {
+    useAuthMock.mockReturnValue({ username: 'admin-alice', logout: vi.fn() });
+    useCanUploadMock.mockReturnValue(true);
+    useIsAdminMock.mockReturnValue(true);
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Channel Wallpaper')).toBeInTheDocument();
   });
 
   it('only shows the Banner URLs nav link to admins', () => {

--- a/webapp-banner-tool/src/App.tsx
+++ b/webapp-banner-tool/src/App.tsx
@@ -2,6 +2,7 @@ import { Link, Routes, Route } from 'react-router-dom';
 import BannerCropper from './components/BannerCropper';
 import ChannelGallery from './components/ChannelGallery';
 import BannerUrlManager from './components/BannerUrlManager';
+import ChannelWallpaperGenerator from './components/ChannelWallpaperGenerator';
 import AccessDenied from './components/AccessDenied';
 import RequireUpload from './components/RequireUpload';
 import RequireAdmin from './components/RequireAdmin';
@@ -27,6 +28,9 @@ export default function App() {
           {isAdmin && (
             <Link to="/banner-urls" className="btn btn-ghost">Banner URLs</Link>
           )}
+          {isAdmin && (
+            <Link to="/wallpaper" className="btn btn-ghost">Channel Wallpaper</Link>
+          )}
           <span>Angemeldet als: <strong>{username}</strong></span>
           <button className="btn btn-ghost" onClick={logout}>Logout</button>
         </div>
@@ -36,6 +40,7 @@ export default function App() {
           <Route path="/" element={<RequireUpload><BannerCropper /></RequireUpload>} />
           <Route path="/channels" element={<RequireUpload><ChannelGallery /></RequireUpload>} />
           <Route path="/banner-urls" element={<RequireAdmin><BannerUrlManager /></RequireAdmin>} />
+          <Route path="/wallpaper" element={<RequireAdmin><ChannelWallpaperGenerator /></RequireAdmin>} />
           <Route path="/access-denied" element={<AccessDenied />} />
         </Routes>
       </main>

--- a/webapp-banner-tool/src/components/ChannelTreePreview.test.tsx
+++ b/webapp-banner-tool/src/components/ChannelTreePreview.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ChannelTreePreview from './ChannelTreePreview';
+
+const { apiFetchJsonMock, showToastMock, getTokenMock } = vi.hoisted(() => ({
+  apiFetchJsonMock: vi.fn(),
+  showToastMock: vi.fn(),
+  getTokenMock: vi.fn(),
+}));
+
+vi.mock('../auth/AuthProvider', () => ({
+  useAuth: () => ({ getToken: getTokenMock }),
+}));
+
+vi.mock('./Toast', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client');
+  return { ...actual, apiFetchJson: apiFetchJsonMock };
+});
+
+const CHANNELS = [
+  { cid: '1', name: 'General', bannerGfxUrl: 'https://x.test/general.png', managed: true, pid: null, depth: 0 },
+  { cid: '2', name: 'Music', bannerGfxUrl: null, managed: false, pid: '1', depth: 1 },
+];
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ChannelTreePreview', () => {
+  it('renders every channel indented by its depth', async () => {
+    apiFetchJsonMock.mockResolvedValue({ channels: CHANNELS });
+    render(<ChannelTreePreview />);
+
+    expect(await screen.findByText('General')).toBeInTheDocument();
+    expect(screen.getByText('Music')).toBeInTheDocument();
+    const musicRow = screen.getByText('Music').closest('.channel-tree-row') as HTMLElement;
+    expect(musicRow.style.paddingLeft).toBe('32px');
+  });
+
+  it('shows a managed badge only for managed channels', async () => {
+    apiFetchJsonMock.mockResolvedValue({ channels: CHANNELS });
+    render(<ChannelTreePreview />);
+
+    await screen.findByText('General');
+    const generalRow = screen.getByText('General').closest('.channel-tree-row') as HTMLElement;
+    const musicRow = screen.getByText('Music').closest('.channel-tree-row') as HTMLElement;
+    expect(generalRow.querySelector('.badge-managed')).not.toBeNull();
+    expect(musicRow.querySelector('.badge-managed')).toBeNull();
+  });
+
+  it('is not clickable when selectable is false (the default)', async () => {
+    apiFetchJsonMock.mockResolvedValue({ channels: CHANNELS });
+    const onSelectParent = vi.fn();
+    render(<ChannelTreePreview onSelectParent={onSelectParent} />);
+
+    const row = await screen.findByText('General');
+    fireEvent.click(row);
+    expect(onSelectParent).not.toHaveBeenCalled();
+  });
+
+  it('calls onSelectParent with the clicked channel cid when selectable', async () => {
+    apiFetchJsonMock.mockResolvedValue({ channels: CHANNELS });
+    const onSelectParent = vi.fn();
+    render(<ChannelTreePreview selectable onSelectParent={onSelectParent} />);
+
+    fireEvent.click(await screen.findByText('Music'));
+    expect(onSelectParent).toHaveBeenCalledWith('2');
+  });
+
+  it('renders a top-level pseudo-row that calls onSelectParent(null) when selectable', async () => {
+    apiFetchJsonMock.mockResolvedValue({ channels: CHANNELS });
+    const onSelectParent = vi.fn();
+    render(<ChannelTreePreview selectable onSelectParent={onSelectParent} />);
+
+    fireEvent.click(await screen.findByText('Top-level (no parent)'));
+    expect(onSelectParent).toHaveBeenCalledWith(null);
+  });
+
+  it('re-fetches when refreshKey changes', async () => {
+    apiFetchJsonMock.mockResolvedValue({ channels: CHANNELS });
+    const { rerender } = render(<ChannelTreePreview refreshKey={0} />);
+    await waitFor(() => expect(apiFetchJsonMock).toHaveBeenCalledTimes(1));
+
+    rerender(<ChannelTreePreview refreshKey={1} />);
+    await waitFor(() => expect(apiFetchJsonMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows an error toast when the fetch fails', async () => {
+    apiFetchJsonMock.mockRejectedValue(new Error('boom'));
+    render(<ChannelTreePreview />);
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalled());
+  });
+});

--- a/webapp-banner-tool/src/components/ChannelTreePreview.tsx
+++ b/webapp-banner-tool/src/components/ChannelTreePreview.tsx
@@ -1,0 +1,107 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { CHANNEL_BANNER_URLS_URL } from '../config';
+import { useAuth } from '../auth/AuthProvider';
+import { apiFetchJson, describeApiError } from '../api/client';
+import { useToast } from './Toast';
+
+export interface TreeChannel {
+  cid: string;
+  name: string;
+  bannerGfxUrl: string | null;
+  managed: boolean;
+  pid: string | null;
+  depth: number;
+}
+
+interface ChannelTreePreviewProps {
+  /** When set, rows (and the top-level pseudo-row) become clickable, calling onSelectParent. */
+  selectable?: boolean;
+  selectedCid?: string | null;
+  onSelectParent?: (cid: string | null) => void;
+  /** Bump this to force a re-fetch, e.g. right after a generate/undo action. */
+  refreshKey?: number;
+}
+
+/**
+ * Renders the entire live TeamSpeak channel tree, each row showing its
+ * actual current banner thumbnail -- every managed channel's banner is
+ * already a public image this server serves, so this is just an <img> per
+ * row, no separate thumbnail endpoint needed. `GET .../channels/banner-urls`
+ * returns channels in the same order ServerQuery's own channellist does,
+ * which TeamSpeak already returns in real tree display order -- so parents
+ * always precede their children and siblings stay in their real order with
+ * no client-side re-sorting required; only the indent (via `depth`) is this
+ * component's own doing.
+ */
+const ChannelTreePreview: React.FC<ChannelTreePreviewProps> = ({
+  selectable = false,
+  selectedCid = null,
+  onSelectParent,
+  refreshKey = 0,
+}) => {
+  const [channels, setChannels] = useState<TreeChannel[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { getToken } = useAuth();
+  const { showToast } = useToast();
+
+  const load = useCallback(() => {
+    setLoading(true);
+    return apiFetchJson<{ channels: TreeChannel[] }>(CHANNEL_BANNER_URLS_URL, { getToken })
+      .then((data) => {
+        if (!Array.isArray(data.channels)) {
+          throw new Error('Response does not contain a valid channels array');
+        }
+        setChannels(data.channels);
+      })
+      .catch((err) => {
+        showToast(describeApiError(err, 'Channel tree could not be loaded'), 'error');
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [getToken, showToast]);
+
+  useEffect(() => {
+    load();
+  }, [load, refreshKey]);
+
+  return (
+    <div className="channel-tree">
+      {loading && <p className="loading-state">Loading channel tree…</p>}
+      {!loading && channels.length === 0 && (
+        <p className="empty-state">No channels found.</p>
+      )}
+      {!loading && (
+        <ul className="channel-tree-list">
+          {selectable && (
+            <li
+              className={`channel-tree-row${selectedCid === null ? ' channel-tree-row-selected' : ''}`}
+              onClick={() => onSelectParent?.(null)}
+            >
+              <span className="channel-tree-thumb channel-tree-thumb-placeholder" />
+              <span className="channel-tree-name">Top-level (no parent)</span>
+            </li>
+          )}
+          {channels.map((channel) => (
+            <li
+              key={channel.cid}
+              className={`channel-tree-row${selectable ? ' channel-tree-row-selectable' : ''}${selectedCid === channel.cid ? ' channel-tree-row-selected' : ''}`}
+              style={{ paddingLeft: 12 + channel.depth * 20 }}
+              onClick={selectable ? () => onSelectParent?.(channel.cid) : undefined}
+            >
+              {channel.bannerGfxUrl ? (
+                <img className="channel-tree-thumb" src={channel.bannerGfxUrl} alt="" />
+              ) : (
+                <span className="channel-tree-thumb channel-tree-thumb-placeholder" />
+              )}
+              <span className="channel-tree-name">{channel.name}</span>
+              {channel.managed && <span className="badge badge-managed">Managed</span>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default ChannelTreePreview;

--- a/webapp-banner-tool/src/components/ChannelWallpaperGenerator.test.tsx
+++ b/webapp-banner-tool/src/components/ChannelWallpaperGenerator.test.tsx
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ChannelWallpaperGenerator from './ChannelWallpaperGenerator';
+
+const { apiFetchJsonMock, showToastMock, getTokenMock } = vi.hoisted(() => ({
+  apiFetchJsonMock: vi.fn(),
+  showToastMock: vi.fn(),
+  getTokenMock: vi.fn(),
+}));
+
+vi.mock('../auth/AuthProvider', () => ({
+  useAuth: () => ({ getToken: getTokenMock }),
+}));
+
+vi.mock('./Toast', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client');
+  return { ...actual, apiFetchJson: apiFetchJsonMock };
+});
+
+// ChannelTreePreview makes its own real apiFetchJson call (mocked above) --
+// stubbed out entirely here since this file's tests are about the
+// generator's own form/preview/submit/undo behavior, not the tree view
+// (already covered by ChannelTreePreview.test.tsx).
+vi.mock('./ChannelTreePreview', () => ({
+  default: () => <div>channel-tree-preview</div>,
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ChannelWallpaperGenerator />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe('ChannelWallpaperGenerator preview', () => {
+  it('does not call the preview endpoint until a source image is provided', async () => {
+    renderPage();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(apiFetchJsonMock).not.toHaveBeenCalled();
+  });
+
+  it('debounces the preview call after a file is selected', async () => {
+    apiFetchJsonMock.mockResolvedValue({ rows: [] });
+    renderPage();
+
+    const file = new File(['bytes'], 'wallpaper.png', { type: 'image/png' });
+    const input = document.getElementById('wallpaper-file-upload') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    // Not yet -- still within the debounce window.
+    await vi.advanceTimersByTimeAsync(200);
+    expect(apiFetchJsonMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(400);
+    expect(apiFetchJsonMock).toHaveBeenCalledTimes(1);
+    const [url, options] = apiFetchJsonMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/channel-wallpaper/preview');
+    expect(options.body).toBeInstanceOf(FormData);
+    expect((options.body as FormData).get('file')).toBe(file);
+  });
+
+  it('renders returned preview rows, indented by depth', async () => {
+    apiFetchJsonMock.mockResolvedValue({
+      rows: [
+        { depth: 0, isSpacer: false, imageDataUrl: 'data:image/png;base64,AAA' },
+        { depth: 1, isSpacer: true, imageDataUrl: 'data:image/png;base64,BBB' },
+      ],
+    });
+    renderPage();
+
+    const file = new File(['bytes'], 'wallpaper.png', { type: 'image/png' });
+    const input = document.getElementById('wallpaper-file-upload') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    await vi.advanceTimersByTimeAsync(600);
+
+    const images = await screen.findAllByRole('img');
+    const previewImages = images.filter((img) => img.classList.contains('wallpaper-preview-row'));
+    expect(previewImages).toHaveLength(2);
+  });
+});
+
+describe('ChannelWallpaperGenerator generate', () => {
+  it('submits the form and shows a success summary', async () => {
+    apiFetchJsonMock.mockImplementation((url: string) => {
+      if (url.includes('/preview')) return Promise.resolve({ rows: [] });
+      return Promise.resolve({
+        createdChannels: [{ cid: '10', name: 'Wall 1', kind: 'art', depth: 0 }],
+        rowCount: 1,
+      });
+    });
+    renderPage();
+
+    const file = new File(['bytes'], 'wallpaper.png', { type: 'image/png' });
+    const input = document.getElementById('wallpaper-file-upload') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    await vi.advanceTimersByTimeAsync(600);
+
+    const submitButton = screen.getByRole('button', { name: 'Generate channels' });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(screen.getByText('Created 1 channel(s).')).toBeInTheDocument());
+    expect(screen.getByText(/Wall 1/)).toBeInTheDocument();
+    expect(showToastMock).toHaveBeenCalledWith('Created 1 channel(s).', 'success');
+  });
+
+  it('disables the generate button until a source image is provided', () => {
+    renderPage();
+    const submitButton = screen.getByRole('button', { name: 'Generate channels' });
+    expect(submitButton).toBeDisabled();
+  });
+});
+
+describe('ChannelWallpaperGenerator undo', () => {
+  async function generateOneChannel() {
+    apiFetchJsonMock.mockImplementation((url: string) => {
+      if (url.includes('/preview')) return Promise.resolve({ rows: [] });
+      if (url.includes('/undo')) return Promise.resolve({ deleted: ['10'], failed: [] });
+      return Promise.resolve({
+        createdChannels: [{ cid: '10', name: 'Wall 1', kind: 'art', depth: 0 }],
+        rowCount: 1,
+      });
+    });
+    renderPage();
+
+    const file = new File(['bytes'], 'wallpaper.png', { type: 'image/png' });
+    const input = document.getElementById('wallpaper-file-upload') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    await vi.advanceTimersByTimeAsync(600);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Generate channels' }));
+    await waitFor(() => expect(screen.getByText('Created 1 channel(s).')).toBeInTheDocument());
+  }
+
+  it('deletes the created channels after confirmation', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    await generateOneChannel();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo this generation' }));
+
+    await waitFor(() =>
+      expect(apiFetchJsonMock).toHaveBeenCalledWith(
+        expect.stringContaining('/channel-wallpaper/undo'),
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+    const undoCall = apiFetchJsonMock.mock.calls.find(([url]) =>
+      (url as string).includes('/undo'),
+    ) as [string, RequestInit];
+    expect(JSON.parse(undoCall[1].body as string)).toEqual({ cids: ['10'] });
+  });
+
+  it('does not undo when the confirmation is declined', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await generateOneChannel();
+    apiFetchJsonMock.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo this generation' }));
+
+    expect(apiFetchJsonMock).not.toHaveBeenCalled();
+  });
+});

--- a/webapp-banner-tool/src/components/ChannelWallpaperGenerator.tsx
+++ b/webapp-banner-tool/src/components/ChannelWallpaperGenerator.tsx
@@ -1,0 +1,419 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  CHANNEL_WALLPAPER_URL,
+  CHANNEL_WALLPAPER_PREVIEW_URL,
+  CHANNEL_WALLPAPER_UNDO_URL,
+} from '../config';
+import { useAuth } from '../auth/AuthProvider';
+import { apiFetchJson, describeApiError, UPLOAD_TIMEOUT_MS } from '../api/client';
+import { useToast } from './Toast';
+import ChannelTreePreview from './ChannelTreePreview';
+
+type SpacerMode = 'flat' | 'nested-spacer';
+
+interface PreviewRow {
+  depth: number;
+  isSpacer: boolean;
+  imageDataUrl: string;
+}
+
+interface CreatedChannel {
+  cid: string;
+  name: string;
+  kind: 'art' | 'spacer';
+  depth: number;
+}
+
+interface GenerateResult {
+  createdChannels: CreatedChannel[];
+  rowCount: number;
+  failedAt?: { name: string; error: string };
+}
+
+// Generation does many ServerQuery round-trips plus one image encode per
+// row, so it can legitimately run much longer than a single image upload.
+const GENERATE_TIMEOUT_MS = 120_000;
+const PREVIEW_DEBOUNCE_MS = 500;
+
+function buildFormData(params: {
+  file: File | null;
+  sourceImageUrl: string;
+  parentCid: string | null;
+  namePrefix: string;
+  spacerMode: SpacerMode;
+  xOffset: string;
+  yOffset: string;
+  backgroundColor: string;
+  coverFitMode: boolean;
+}): FormData {
+  const formData = new FormData();
+  if (params.file) {
+    formData.append('file', params.file);
+  } else if (params.sourceImageUrl.trim()) {
+    formData.append('sourceImageUrl', params.sourceImageUrl.trim());
+  }
+  if (params.parentCid) formData.append('parentCid', params.parentCid);
+  formData.append('namePrefix', params.namePrefix);
+  formData.append('spacerMode', params.spacerMode);
+  if (params.xOffset.trim()) formData.append('xOffset', params.xOffset.trim());
+  if (params.yOffset.trim()) formData.append('yOffset', params.yOffset.trim());
+  if (params.backgroundColor.trim()) {
+    formData.append('backgroundColor', params.backgroundColor.trim());
+  }
+  formData.append('coverFitMode', params.coverFitMode ? 'true' : 'false');
+  return formData;
+}
+
+const ChannelWallpaperGenerator: React.FC = () => {
+  const [file, setFile] = useState<File | null>(null);
+  const [sourceImageUrl, setSourceImageUrl] = useState('');
+  const [dragOver, setDragOver] = useState(false);
+  const [parentCid, setParentCid] = useState<string | null>(null);
+  const [namePrefix, setNamePrefix] = useState('Wallpaper');
+  const [spacerMode, setSpacerMode] = useState<SpacerMode>('flat');
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [xOffset, setXOffset] = useState('');
+  const [yOffset, setYOffset] = useState('');
+  const [backgroundColor, setBackgroundColor] = useState('#00000000');
+  const [coverFitMode, setCoverFitMode] = useState(true);
+
+  const [previewRows, setPreviewRows] = useState<PreviewRow[]>([]);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [undoing, setUndoing] = useState(false);
+  const [result, setResult] = useState<GenerateResult | null>(null);
+  const [treeRefreshKey, setTreeRefreshKey] = useState(0);
+
+  const navigate = useNavigate();
+  const { getToken } = useAuth();
+  const { showToast } = useToast();
+
+  const hasSource = Boolean(file) || sourceImageUrl.trim().length > 0;
+
+  // Debounced live preview: re-runs the real slicing endpoint (not a
+  // reimplemented client-side approximation) shortly after any input that
+  // affects the sliced output changes, so what's shown here can never drift
+  // from what generation will actually produce.
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  useEffect(() => {
+    if (!hasSource) {
+      setPreviewRows([]);
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setPreviewLoading(true);
+      apiFetchJson<{ rows: PreviewRow[] }>(CHANNEL_WALLPAPER_PREVIEW_URL, {
+        method: 'POST',
+        body: buildFormData({
+          file,
+          sourceImageUrl,
+          parentCid,
+          namePrefix,
+          spacerMode,
+          xOffset,
+          yOffset,
+          backgroundColor,
+          coverFitMode,
+        }),
+        getToken,
+        timeoutMs: UPLOAD_TIMEOUT_MS,
+      })
+        .then((data) => setPreviewRows(data.rows))
+        .catch((err) => {
+          showToast(describeApiError(err, 'Preview could not be generated'), 'error');
+        })
+        .finally(() => setPreviewLoading(false));
+    }, PREVIEW_DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [file, sourceImageUrl, parentCid, spacerMode, xOffset, yOffset, backgroundColor, coverFitMode, hasSource]);
+
+  const handleDropzoneDrop = useCallback((e: React.DragEvent<HTMLLabelElement>) => {
+    e.preventDefault();
+    setDragOver(false);
+    const dropped = e.dataTransfer.files?.[0];
+    if (dropped) {
+      setFile(dropped);
+      setSourceImageUrl('');
+    }
+  }, []);
+
+  const handleSubmit = async () => {
+    if (!hasSource) {
+      showToast('Provide an image file or a source image URL first.', 'error');
+      return;
+    }
+    setSubmitting(true);
+    setResult(null);
+    try {
+      const data = await apiFetchJson<GenerateResult>(CHANNEL_WALLPAPER_URL, {
+        method: 'POST',
+        body: buildFormData({
+          file,
+          sourceImageUrl,
+          parentCid,
+          namePrefix,
+          spacerMode,
+          xOffset,
+          yOffset,
+          backgroundColor,
+          coverFitMode,
+        }),
+        getToken,
+        timeoutMs: GENERATE_TIMEOUT_MS,
+      });
+      setResult(data);
+      setTreeRefreshKey((k) => k + 1);
+      if (data.failedAt) {
+        showToast(
+          `Created ${data.rowCount} channel(s), then stopped: ${data.failedAt.error}`,
+          'error',
+        );
+      } else {
+        showToast(`Created ${data.rowCount} channel(s).`, 'success');
+      }
+    } catch (err) {
+      showToast(describeApiError(err, 'Channel wallpaper could not be generated'), 'error');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleUndo = async () => {
+    if (!result || result.createdChannels.length === 0) return;
+    const confirmed = window.confirm(
+      `Delete the ${result.createdChannels.length} channel(s) just created?`,
+    );
+    if (!confirmed) return;
+
+    setUndoing(true);
+    try {
+      const cids = result.createdChannels.map((c) => c.cid);
+      const outcome = await apiFetchJson<{ deleted: string[]; failed: { cid: string; error: string }[] }>(
+        CHANNEL_WALLPAPER_UNDO_URL,
+        { method: 'POST', body: JSON.stringify({ cids }), headers: { 'Content-Type': 'application/json' }, getToken },
+      );
+      showToast(
+        outcome.failed.length > 0
+          ? `Deleted ${outcome.deleted.length}, ${outcome.failed.length} failed.`
+          : `Deleted ${outcome.deleted.length} channel(s).`,
+        outcome.failed.length > 0 ? 'error' : 'success',
+      );
+      setResult(null);
+      setTreeRefreshKey((k) => k + 1);
+    } catch (err) {
+      showToast(describeApiError(err, 'Undo failed'), 'error');
+    } finally {
+      setUndoing(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="gallery-header">
+        <button type="button" className="btn btn-ghost" onClick={() => navigate('/')}>← Back</button>
+        <h2>Channel wallpaper generator</h2>
+      </div>
+
+      <div className="card">
+        <h2 className="card-title">1. Source image</h2>
+        <label
+          className={`dropzone${dragOver ? ' dropzone-drag-over' : ''}`}
+          htmlFor="wallpaper-file-upload"
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragOver(true);
+          }}
+          onDragLeave={(e) => {
+            if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+            setDragOver(false);
+          }}
+          onDrop={handleDropzoneDrop}
+        >
+          {file ? `Selected: ${file.name}` : 'Drag & drop the wallpaper image here, or click to browse'}
+          <input
+            type="file"
+            id="wallpaper-file-upload"
+            accept="image/*"
+            onChange={(e) => {
+              const chosen = e.target.files?.[0];
+              if (chosen) {
+                setFile(chosen);
+                setSourceImageUrl('');
+              }
+            }}
+          />
+        </label>
+        <div className="field">
+          <label className="label" htmlFor="wallpaper-source-url">Or load from a URL instead</label>
+          <input
+            className="input"
+            id="wallpaper-source-url"
+            type="url"
+            placeholder="https://example.com/wallpaper.png"
+            value={sourceImageUrl}
+            onChange={(e) => {
+              setSourceImageUrl(e.target.value);
+              if (e.target.value) setFile(null);
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="card">
+        <h2 className="card-title">2. Parent channel</h2>
+        <p style={{ marginTop: 0 }}>Click a channel below to nest the generated wallpaper under it, or leave "Top-level" selected.</p>
+        <ChannelTreePreview
+          selectable
+          selectedCid={parentCid}
+          onSelectParent={setParentCid}
+          refreshKey={treeRefreshKey}
+        />
+      </div>
+
+      <div className="card">
+        <h2 className="card-title">3. Options</h2>
+        <div className="field">
+          <label className="label" htmlFor="wallpaper-name-prefix">Channel name prefix</label>
+          <input
+            className="input"
+            id="wallpaper-name-prefix"
+            type="text"
+            value={namePrefix}
+            onChange={(e) => setNamePrefix(e.target.value)}
+          />
+        </div>
+        <div className="field">
+          <span className="label">Spacer mode</span>
+          <div className="actions-row">
+            <button
+              type="button"
+              className={spacerMode === 'flat' ? 'btn btn-primary' : 'btn btn-secondary'}
+              onClick={() => setSpacerMode('flat')}
+            >
+              Flat
+            </button>
+            <button
+              type="button"
+              className={spacerMode === 'nested-spacer' ? 'btn btn-primary' : 'btn btn-secondary'}
+              onClick={() => setSpacerMode('nested-spacer')}
+            >
+              Nested spacer
+            </button>
+          </div>
+        </div>
+        <button type="button" className="btn btn-ghost" onClick={() => setAdvancedOpen((v) => !v)}>
+          {advancedOpen ? '▾ Hide advanced options' : '▸ Advanced options'}
+        </button>
+        {advancedOpen && (
+          <>
+            <div className="input-row">
+              <div className="field">
+                <label className="label" htmlFor="wallpaper-x-offset">X offset (px)</label>
+                <input
+                  className="input"
+                  id="wallpaper-x-offset"
+                  type="number"
+                  value={xOffset}
+                  onChange={(e) => setXOffset(e.target.value)}
+                />
+              </div>
+              <div className="field">
+                <label className="label" htmlFor="wallpaper-y-offset">Y offset (px)</label>
+                <input
+                  className="input"
+                  id="wallpaper-y-offset"
+                  type="number"
+                  value={yOffset}
+                  onChange={(e) => setYOffset(e.target.value)}
+                />
+              </div>
+            </div>
+            <div className="field">
+              <label className="label" htmlFor="wallpaper-bg-color">Background color (#RRGGBBAA)</label>
+              <input
+                className="input"
+                id="wallpaper-bg-color"
+                type="text"
+                value={backgroundColor}
+                onChange={(e) => setBackgroundColor(e.target.value)}
+              />
+            </div>
+            <div className="field">
+              <label className="label">
+                <input
+                  type="checkbox"
+                  checked={coverFitMode}
+                  onChange={(e) => setCoverFitMode(e.target.checked)}
+                />
+                {' '}Cover-fit mode (widen the source so nested rows still show real content)
+              </label>
+            </div>
+          </>
+        )}
+      </div>
+
+      <div className="card">
+        <h2 className="card-title">4. Preview</h2>
+        {previewLoading && <p className="loading-state">Slicing preview…</p>}
+        {!previewLoading && previewRows.length === 0 && (
+          <p className="empty-state">Add a source image to see a preview.</p>
+        )}
+        {!previewLoading && previewRows.length > 0 && (
+          <div className="wallpaper-preview-stack">
+            {previewRows.map((row, i) => (
+              <img
+                key={i}
+                src={row.imageDataUrl}
+                alt={row.isSpacer ? 'spacer row' : 'channel row'}
+                style={{ marginLeft: row.depth * 20 }}
+                className="wallpaper-preview-row"
+              />
+            ))}
+          </div>
+        )}
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={handleSubmit}
+          disabled={submitting || !hasSource}
+        >
+          {submitting ? 'Generating…' : 'Generate channels'}
+        </button>
+      </div>
+
+      {result && (
+        <div className="card">
+          <h2 className="card-title">Result</h2>
+          <p>Created {result.rowCount} channel(s).</p>
+          {result.failedAt && (
+            <p className="alert alert-error">
+              Stopped at "{result.failedAt.name}": {result.failedAt.error}
+            </p>
+          )}
+          <ul>
+            {result.createdChannels.map((c) => (
+              <li key={c.cid}>
+                {c.name} ({c.kind}, depth {c.depth})
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            className="btn btn-danger"
+            onClick={handleUndo}
+            disabled={undoing}
+          >
+            {undoing ? 'Undoing…' : 'Undo this generation'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ChannelWallpaperGenerator;

--- a/webapp-banner-tool/src/config.ts
+++ b/webapp-banner-tool/src/config.ts
@@ -8,6 +8,9 @@ export const GET_CHANNELS_LIST_URL = `${ADMIN_API_URL}/images-local/channels`;
 export const CHANNEL_BANNER_URLS_URL = `${ADMIN_API_URL}/images-local/channels/banner-urls`;
 export const APPLY_BANNER_URLS_URL = `${ADMIN_API_URL}/images-local/channels/apply-banner-urls`;
 export const SPACER_BASE_IMAGE_URL = `${ADMIN_API_URL}/images-local/spacer-base-image`;
+export const CHANNEL_WALLPAPER_URL = `${ADMIN_API_URL}/images-local/channel-wallpaper`;
+export const CHANNEL_WALLPAPER_PREVIEW_URL = `${ADMIN_API_URL}/images-local/channel-wallpaper/preview`;
+export const CHANNEL_WALLPAPER_UNDO_URL = `${ADMIN_API_URL}/images-local/channel-wallpaper/undo`;
 
 // Keycloak Configuration
 //

--- a/webapp-banner-tool/src/styles/banner-tool.css
+++ b/webapp-banner-tool/src/styles/banner-tool.css
@@ -472,3 +472,79 @@ h1, h2, h3 {
   background: var(--color-bg);
   color: var(--color-text-muted);
 }
+
+/* Channel tree preview (ChannelTreePreview) */
+
+.channel-tree {
+  max-height: 360px;
+  overflow-y: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+}
+
+.channel-tree-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+}
+
+.channel-tree-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: 14px;
+}
+
+.channel-tree-row-selectable {
+  cursor: pointer;
+}
+
+.channel-tree-row-selectable:hover {
+  background: rgba(37, 99, 235, 0.06);
+}
+
+.channel-tree-row-selected {
+  background: rgba(37, 99, 235, 0.12);
+  font-weight: 600;
+}
+
+.channel-tree-thumb {
+  width: 40px;
+  height: 4px;
+  object-fit: cover;
+  border-radius: 2px;
+  flex-shrink: 0;
+  background: var(--color-border);
+}
+
+.channel-tree-thumb-placeholder {
+  background: var(--color-border);
+}
+
+.channel-tree-name {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Channel wallpaper generator preview strip */
+
+.wallpaper-preview-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 16px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.wallpaper-preview-row {
+  width: 500px;
+  max-width: 100%;
+  height: 44px;
+  image-rendering: pixelated;
+  border: 1px solid var(--color-border);
+}


### PR DESCRIPTION
…ge across them

Slices one large uploaded image into per-channel banner strips and creates the whole channel tree via ServerQuery in one admin action, instead of the manual "slice then hand-paste each banner URL" workflow a hand-built channel tree previously required. The row-count/depth-offset/cover-fit slicing behavior is independently implemented (not copied) from a reference tool's documented behavior, since that project carries no license; a few of its details (a sizeRatio double-scaling quirk, a dead crop-width parameter, a crash-prone fixed-256-row array) were deliberately not carried over.

Also adds a live channel-tree preview (with real banner thumbnails) to the admin UI, reused both as the parent-channel picker for this feature and as a general "see the current server structure" view, since the depth/parent data needed for one already covers the other.


Claude-Session: https://claude.ai/code/session_01KTFBDwcAWTfVRTzTtTQJaE